### PR TITLE
Update schema to support offence date ranges

### DIFF
--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -34,7 +34,7 @@ module LaaCrimeSchemas
         attribute? :appeal_with_changes_maat_id, Types::String.optional
         attribute? :appeal_with_changes_details, Types::String.optional
 
-        attribute :offences, Types::Array.of(Offence)
+        attribute :offences, Types::Array.of(Offence).constrained(min_size: 1)
         attribute :codefendants, Types::Array.of(Codefendant).default([].freeze)
 
         attribute :hearing_court_name, Types::String

--- a/lib/laa_crime_schemas/structs/offence.rb
+++ b/lib/laa_crime_schemas/structs/offence.rb
@@ -5,7 +5,15 @@ module LaaCrimeSchemas
     class Offence < Base
       attribute :name, Types::String
       attribute? :offence_class, Types::String.optional
-      attribute :dates, Types::Array.of(Types::JSON::Date).constrained(min_size: 1)
+      attribute :dates, Types::Array.constrained(min_size: 1)
+
+      # Use the following, more strict attribute definition once the
+      # existing applications conforms to the new format.
+      #
+      # attribute :dates, Types::Array.of(Base).constrained(min_size: 1) do
+      #   attribute :date_from, Types::JSON::Date
+      #   attribute :date_to, Types::JSON::Date.optional
+      # end
     end
   end
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -44,6 +44,7 @@
         "appeal_with_changes_details": { "type": ["string", "null"] },
         "offences": {
           "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/definitions/offence" }
         },
         "codefendants": {

--- a/schemas/1.0/general/offence.json
+++ b/schemas/1.0/general/offence.json
@@ -10,7 +10,14 @@
     "dates": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string", "format": "date" }
+      "items": {
+        "type": "object",
+        "properties": {
+          "date_from": { "type": "string", "format": "date" },
+          "date_to": { "type": ["string", "null"], "format": "date" }
+        },
+        "required": ["date_from"]
+      }
     }
   },
   "required": ["name", "dates"]

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -40,12 +40,17 @@
       {
         "name": "Attempt robbery",
         "offence_class": "Class C",
-        "dates": ["2020-05-11", "2020-08-11"]
+        "dates": [
+          { "date_from": "2020-05-11", "date_to": "2020-05-12" },
+          { "date_from": "2020-08-11", "date_to": null }
+        ]
       },
       {
         "name": "Non-listed offence, manually entered",
         "offence_class": null,
-        "dates": ["2020-09-15"]
+        "dates": [
+          { "date_from": "2020-09-15", "date_to": null }
+        ]
       }
     ],
     "codefendants": [

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -32,7 +32,10 @@
       {
         "name": "Attempt robbery",
         "offence_class": "Class C",
-        "dates": ["2020-05-11", "2020-08-11"]
+        "dates": [
+          { "date_from": "2020-05-11", "date_to": "2020-05-12" },
+          { "date_from": "2020-08-11", "date_to": null }
+        ]
       }
     ],
     "codefendants": [],


### PR DESCRIPTION
After this change is introduced in the datastore, new submitted applications will have to conform to the new format for offence dates (`date_from` and `date_to`).

However to keep compatibility and less disruptive with already submitted applications, the struct counterpart will still support a simple array and will not enforce the content of the objects in the array for the time being.

This will be enforced at a later time.