### PR TITLE
Crimre 52 return reason types

### DIFF
--- a/lib/laa_crime_schemas.rb
+++ b/lib/laa_crime_schemas.rb
@@ -19,6 +19,7 @@ require_relative 'laa_crime_schemas/structs/address'
 require_relative 'laa_crime_schemas/structs/person'
 require_relative 'laa_crime_schemas/structs/applicant'
 require_relative 'laa_crime_schemas/structs/codefendant'
+require_relative 'laa_crime_schemas/structs/return_details'
 require_relative 'laa_crime_schemas/structs/crime_application'
 
 module LaaCrimeSchemas

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -29,7 +29,6 @@ module LaaCrimeSchemas
 
       attribute :case_details, Base do
         attribute :urn, Types::String.optional
-
         attribute :case_type, Types::CaseType
         attribute? :appeal_maat_id, Types::String.optional
         attribute? :appeal_with_changes_maat_id, Types::String.optional
@@ -46,6 +45,8 @@ module LaaCrimeSchemas
         attribute :type, Types::IojType
         attribute :reason, Types::String
       end
+
+      attribute? :return_details, ReturnDetails
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/return_details.rb
+++ b/lib/laa_crime_schemas/structs/return_details.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Structs
+    class ReturnDetails < Base
+      attribute :reason, Types::ReturnReason
+      attribute :details, Types::String
+      attribute :returned_at, Types::JSON::DateTime
+    end
+  end
+end

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -66,10 +66,6 @@ module LaaCrimeSchemas
       provider_request
     ].freeze
     ReturnReason = String.enum(*RETURN_REASONS)
-    ReturnDetails = Hash.schema(
-      reason: ReturnReason,
-      details: String
-    )
 
     REVIEW_APPLICATION_STATUSES = %w[
       application_received

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -58,6 +58,19 @@ module LaaCrimeSchemas
     ].freeze
     IojPassportType = String.enum(*IOJ_PASSPORT_TYPES)
 
+    RETURN_REASONS = %w[
+      clarification_required
+      evidence_issue
+      duplicate_application
+      case_concluded
+      provider_request
+    ].freeze
+    ReturnReason = String.enum(*RETURN_REASONS)
+    ReturnDetails = Hash.schema(
+      reason: ReturnReason,
+      details: String
+    )
+
     REVIEW_APPLICATION_STATUSES = %w[
       application_received
       returned_to_provider

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -69,6 +69,15 @@
           "reason": { "type": "string" }
         }
       }
+    },
+    "return_details": {
+      "type": "object",
+      "properties": {
+        "reason": { "type": "string", "enum": ["clarification_required", "evidence_issue", "duplicate_application", "case_concluded", "provider_request"] },
+        "details": { "type": "string" },
+    	"returned_at": { "type": "string", "format": "date-time" }
+      },
+      "required": ["reason", "returned_at"]
     }
   },
   "required": [

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -43,5 +43,10 @@
     "hearing_court_name": "Cardiff Magistrates' Court",
     "hearing_date": "2024-11-11"
   },
-  "interests_of_justice": null
+  "interests_of_justice": null,
+  "return_details": {
+    "reason": "clarification_required",
+    "details": "Further information regarding IoJ required",
+    "returned_at": "2022-09-27T14:10:00.000+00:00"
+  }
 }

--- a/spec/laa_crime_schemas/structs/crime_application_spec.rb
+++ b/spec/laa_crime_schemas/structs/crime_application_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe LaaCrimeSchemas::Structs::CrimeApplication do
 
   describe 'schema version 1.0' do
     let(:valid_fixture) { 'application/1.0/application.json' }
+    let(:returned_fixture) { 'application/1.0/application_returned.json' }
     let(:invalid_fixture) { 'application/1.0/application_invalid.json' }
 
     context 'for a valid crime application object' do
@@ -30,6 +31,22 @@ RSpec.describe LaaCrimeSchemas::Structs::CrimeApplication do
 
       it 'raises an error' do
         expect { subject }.to raise_error(Dry::Struct::Error, /case_details/)
+      end
+    end
+
+    context 'for a valid returned JSON document' do
+      let(:attributes) do
+        JSON.parse(file_fixture(returned_fixture).read)
+      end
+
+      it 'includes the return_details' do
+        expect(subject.return_details).to be_a LaaCrimeSchemas::Structs::ReturnDetails
+      end
+
+      it 'produces a valid JSON document conforming to the schema' do
+        expect(
+          LaaCrimeSchemas::Validator.new(subject.to_json)
+        ).to be_valid
       end
     end
   end

--- a/spec/laa_crime_schemas/structs/return_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/return_details_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe LaaCrimeSchemas::Structs::ReturnDetails do
+  subject { described_class.new(attributes) }
+
+  let(:valid_details) do
+    JSON.parse(
+      LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read
+    )['return_details']
+  end
+
+  describe '.new' do
+    context 'for a valid address object' do
+      let(:attributes) { valid_details }
+
+      it 'builds the return details struct' do
+        expect(subject.reason).to eq('clarification_required')
+        expect(subject.details).to eq('Further information regarding IoJ required')
+        expect(subject.returned_at.to_s).to eq('2022-09-27T14:10:00+00:00')
+      end
+    end
+
+    context 'with invalid reason' do
+      let(:attributes) do
+        valid_details.merge(reason: "not_a_reason")
+      end
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Dry::Struct::Error, /invalid type for :reason/)
+      end
+    end
+    
+    context 'with missing details' do
+      let(:attributes) do
+        valid_details.merge(details: nil)
+      end
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Dry::Struct::Error, /invalid type for :details/)
+      end
+    end
+    
+    context 'with missing returned_at' do
+      let(:attributes) do
+        valid_details.merge(returned_at: nil)
+      end
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Dry::Struct::Error, /invalid type for :returned_at/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add return_details to: Types, Structs, Schema, and fixtures.

[CRIMRE-52](https://dsdmoj.atlassian.net/browse/CRIMRE-52)

[CRIMRE-52]: https://dsdmoj.atlassian.net/browse/CRIMRE-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ