### PR TITLE
Add split_case return reason

### DIFF
--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -65,6 +65,7 @@ module LaaCrimeSchemas
       duplicate_application
       case_concluded
       provider_request
+      split_case
     ].freeze
     ReturnReason = String.enum(*RETURN_REASONS)
 


### PR DESCRIPTION
To allow for a case split by the CPS to be returned by the caseworker to the provider return reason type of split_case is needed