### PR TITLE
Add MAAT application schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ For instance, to validate against version `1.0` of the JSON schema:
 => true
 ```
 
+You can also use the `LaaCrimeSchemas::Validator` class to validate a document against the MAAT application JSON schema.
+
+For instance
+
+```ruby
+=> LaaCrimeSchemas::Validator.new(document, version: 1.0, schema_name: 'maat_application').valid?
+=> true
+```
+
 If you don't provide the version to the initialise, then the validator will try to obtain the version from the document itself, 
 assuming there is a property named `schema_version`.
 

--- a/lib/laa_crime_schemas/validator.rb
+++ b/lib/laa_crime_schemas/validator.rb
@@ -6,9 +6,10 @@ module LaaCrimeSchemas
 
     attr_reader :document, :version
 
-    def initialize(document, version: nil)
+    def initialize(document, version: nil, schema_name: 'application')
       @document = document
       @version = version
+      @schema_name = schema_name
     end
 
     def schema_version
@@ -33,8 +34,10 @@ module LaaCrimeSchemas
 
     private
 
+    attr_reader :schema_name
+
     def schema
-      File.join(LaaCrimeSchemas.root, 'schemas', schema_version.to_s, 'application.json')
+      File.join(LaaCrimeSchemas.root, 'schemas', schema_version.to_s, "#{schema_name}.json")
     end
 
     def version_from_document

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "ministryofjustice/laa-criminal-legal-aid-schemas/main/schemas/1.0/maat_application.json",
+  "title": "An application for criminal legal aid for MAAT",
+  "description": "Attributes of a criminal legal aid application for MAAT",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "schema_version": { "type": "number" },
+    "application_type": { "type": "string" },
+    "reference": { "type": "number" },
+    "submitted_at": { "type": "string", "format": "date-time" },
+    "date_stamp": { "type": "string", "format": "date-time" },
+    "ioj_passport": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "provider_details": {
+      "type": "object",
+      "properties": {
+        "office_code": { "type": "string", "minLength": 1 },
+        "provider_email": { "type": "string" },
+        "legal_rep_first_name": { "type": "string" },
+        "legal_rep_last_name": { "type": "string" },
+        "legal_rep_telephone": { "type": "string" }
+      },
+      "required": [
+        "office_code", "provider_email",
+        "legal_rep_first_name", "legal_rep_last_name", "legal_rep_telephone"
+      ]
+    },
+    "client_details": {
+      "type": "object",
+      "properties": {
+        "applicant": { "$ref": "#/definitions/applicant" }
+      },
+      "required": ["applicant"]
+    },
+    "case_details": {
+      "type": "object",
+      "properties": {
+        "urn": { "type": ["string", "null"] },
+        "case_type": { "type": "string" },
+        "appeal_maat_id": { "type": ["string", "null"] },
+        "appeal_with_changes_maat_id": { "type": ["string", "null"] },
+        "appeal_with_changes_details": { "type": ["string", "null"] },
+        "offence_class": { "type": ["string", "null"] },
+        "hearing_court_name": { "type": "string" },
+        "hearing_date": { "type": "string", "format": "date" }
+      },
+      "required": ["case_type", "hearing_court_name", "hearing_date", "offence_class"]
+    },
+    "interests_of_justice": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    }
+  },
+  "required": [
+    "id", "schema_version", "reference", "submitted_at", "date_stamp",
+    "provider_details", "client_details", "case_details", "interests_of_justice"
+  ],
+  "definitions": {
+    "applicant": { "$ref": "general/applicant.json" }
+  }
+}

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -1,0 +1,48 @@
+{
+  "id": "696dd4fd-b619-4637-ab42-a5f4565bcf4a",
+  "schema_version": 1.0,
+  "reference": 6000001,
+  "submitted_at": "2022-10-24T09:50:04.000+00:00",
+  "date_stamp": "2022-10-24T09:50:04.000+00:00",
+  "ioj_passport": [],
+  "provider_details": {
+    "office_code": "1A123B",
+    "provider_email": "provider@example.com",
+    "legal_rep_first_name": "John",
+    "legal_rep_last_name": "Doe",
+    "legal_rep_telephone": "123456789"
+  },
+  "client_details": {
+    "applicant": {
+      "first_name": "Kit",
+      "last_name": "Pound",
+      "nino": "AJ123456C",
+      "date_of_birth": "2011-06-09",
+      "telephone_number": "07771231231",
+      "correspondence_address_type": "home_address",
+      "home_address": {
+        "lookup_id": null,
+        "address_line_one": "1 Road",
+        "address_line_two": "Village",
+        "city": "Some nice city",
+        "country": "United Kingdom",
+        "postcode": "SW1A 2AA"
+      },
+      "correspondence_address": null
+    }
+  },
+  "case_details": {
+    "urn": "",
+    "case_type": "appeal_to_crown_court",
+    "offence_class": "A",
+    "appeal_maat_id": null,
+    "hearing_court_name": "Cardiff Magistrates' Court",
+    "hearing_date": "2024-11-11"
+  },
+  "interests_of_justice": [
+    {
+      "type": "loss_of_liberty",
+      "reason": "More details about loss of liberty."
+    }
+  ]
+}

--- a/spec/fixtures/application/1.0/maat_application_invalid.json
+++ b/spec/fixtures/application/1.0/maat_application_invalid.json
@@ -1,0 +1,47 @@
+{
+  "id": "696dd4fd-b619-4637-ab42-a5f4565bcf4a",
+  "schema_version": 1.0,
+  "reference": 6000001,
+  "submitted_at": "2022-10-24T09:50:04.000+00:00",
+  "date_stamp": "2022-10-24T09:50:04.000+00:00",
+  "ioj_passport": [],
+  "provider_details": {
+    "office_code": "1A123B",
+    "provider_email": "provider@example.com",
+    "legal_rep_first_name": "John",
+    "legal_rep_last_name": "Doe",
+    "legal_rep_telephone": "123456789"
+  },
+  "client_details": {
+    "applicant": {
+      "first_name": "Kit",
+      "last_name": "Pound",
+      "nino": "AJ123456C",
+      "date_of_birth": "2011-06-09",
+      "telephone_number": "07771231231",
+      "correspondence_address_type": "home_address",
+      "home_address": {
+        "lookup_id": null,
+        "address_line_one": "1 Road",
+        "address_line_two": "Village",
+        "city": "Some nice city",
+        "country": "United Kingdom",
+        "postcode": "SW1A 2AA"
+      },
+      "correspondence_address": null
+    }
+  },
+  "case_details": {
+    "urn": "",
+    "case_type": "appeal_to_crown_court",
+    "appeal_maat_id": null,
+    "hearing_court_name": "Cardiff Magistrates' Court",
+    "hearing_date": "2024-11-11"
+  },
+  "interests_of_justice": [
+    {
+      "type": "loss_of_liberty",
+      "reason": "More details about loss of liberty."
+    }
+  ]
+}

--- a/spec/laa_crime_schemas/validator_spec.rb
+++ b/spec/laa_crime_schemas/validator_spec.rb
@@ -84,4 +84,39 @@ RSpec.describe LaaCrimeSchemas::Validator do
       it { expect(subject).to be_valid }
     end
   end
+
+  describe 'maat application, schema version 1.0' do
+    subject { described_class.new(document, version: version, schema_name: 'maat_application') }
+
+    let(:valid_fixture) { 'application/1.0/maat_application.json' }
+    let(:invalid_fixture) { 'application/1.0/maat_application_invalid.json' }
+
+    describe '#valid?' do
+      context 'when the document is valid' do
+        let(:document) { file_fixture(valid_fixture).read }
+
+        it { expect(subject).to be_valid }
+      end
+
+      context 'when the document is not valid' do
+        let(:document) { file_fixture(invalid_fixture).read }
+
+        it { expect(subject).not_to be_valid }
+      end
+    end
+
+    describe '#fully_validate' do
+      context 'when the document is valid' do
+        let(:document) { file_fixture(valid_fixture).read }
+
+        it { expect(subject.fully_validate).to be_empty }
+      end
+
+      context 'when the document is not valid' do
+        let(:document) { file_fixture(invalid_fixture).read }
+
+        it { expect(subject.fully_validate).not_to be_empty }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add a specific schema for MAAT.

# Notes for reviewer

This adds the initial version of the maat_application schema, which is designed to be used exclusively by the MAAT api.

We decided to create a separate schema to allow for changes to the main application schema used by Apply and Review without requiring updates to MAAT. Additionally, there are some attributes that are not necessary for MAAT.

We decided against using namespaces for the MAAT schema for a few reasons, primarily because it would necessitate modifying multiple utilities that come with this gem.