### PR TITLE
Calculate overall offence class for maat integration

### DIFF
--- a/lib/laa_crime_schemas.rb
+++ b/lib/laa_crime_schemas.rb
@@ -10,6 +10,7 @@ require_relative 'laa_crime_schemas/errors'
 require_relative 'laa_crime_schemas/validator'
 
 require_relative 'laa_crime_schemas/traits/full_name'
+require_relative 'laa_crime_schemas/traits/offence_class'
 
 require_relative 'laa_crime_schemas/types/types'
 

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -36,6 +36,7 @@ module LaaCrimeSchemas
 
         attribute :offences, Types::Array.of(Offence).constrained(min_size: 1)
         attribute :codefendants, Types::Array.of(Codefendant).default([].freeze)
+        include Traits::OffenceClass
 
         attribute :hearing_court_name, Types::String
         attribute :hearing_date, Types::JSON::Date

--- a/lib/laa_crime_schemas/traits/offence_class.rb
+++ b/lib/laa_crime_schemas/traits/offence_class.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Traits
+    module OffenceClass
+      OFFENCE_CLASS_RANKING = %w[
+        a
+        k
+        g
+        b
+        i
+        j
+        d
+        c
+        h
+        f
+        e
+      ].freeze
+
+      def offence_class
+        if any_manually_entered?
+          nil
+        else
+          highest_ranking_offence_class
+        end
+      end
+
+      private
+
+      def highest_ranking_offence_class
+        rank_offences.first
+      end
+
+      def rank_offences
+        offences_classes = attributes[:offences].map(&:offence_class)
+        offences_classes.sort_by { |oc| OFFENCE_CLASS_RANKING.index oc.downcase }
+      end
+
+      def any_manually_entered?
+        attributes[:offences].any? { |o| o.offence_class.nil? }
+      end
+    end
+  end
+end

--- a/lib/laa_crime_schemas/traits/offence_class.rb
+++ b/lib/laa_crime_schemas/traits/offence_class.rb
@@ -3,19 +3,7 @@
 module LaaCrimeSchemas
   module Traits
     module OffenceClass
-      OFFENCE_CLASS_RANKING = %w[
-        a
-        k
-        g
-        b
-        i
-        j
-        d
-        c
-        h
-        f
-        e
-      ].freeze
+      OFFENCE_CLASS_RANKING = %w[a k g b i j d c h f e].freeze
 
       def offence_class
         if any_manually_entered?

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -40,7 +40,7 @@
     "offences": [
       {
         "name": "Attempt robbery",
-        "offence_class": "Class C",
+        "offence_class": "C",
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }

--- a/spec/fixtures/application/1.0/application_completed.json
+++ b/spec/fixtures/application/1.0/application_completed.json
@@ -33,7 +33,7 @@
     "offences": [
       {
         "name": "Attempt robbery",
-        "offence_class": "Class C",
+        "offence_class": "C",
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -32,7 +32,15 @@
     "offences": [
       {
         "name": "Attempt robbery",
-        "offence_class": "Class C",
+        "offence_class": "C",
+        "dates": [
+          { "date_from": "2020-05-11", "date_to": "2020-05-12" },
+          { "date_from": "2020-08-11", "date_to": null }
+        ]
+      },
+      {
+        "name": "Homicide",
+        "offence_class": "A",
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }

--- a/spec/fixtures/application/1.0/application_returned_split_case.json
+++ b/spec/fixtures/application/1.0/application_returned_split_case.json
@@ -32,7 +32,7 @@
     "offences": [
       {
         "name": "Attempt robbery",
-        "offence_class": "Class C",
+        "offence_class": "C",
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }

--- a/spec/laa_crime_schemas/structs/crime_application_spec.rb
+++ b/spec/laa_crime_schemas/structs/crime_application_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe LaaCrimeSchemas::Structs::CrimeApplication do
           LaaCrimeSchemas::Validator.new(subject.to_json)
         ).to be_valid
       end
+
+      it 'has an undertermined offence class' do
+        expect(subject.case_details.offence_class).to eq(nil)
+      end
     end
 
     context 'for an invalid crime application object' do
@@ -47,6 +51,10 @@ RSpec.describe LaaCrimeSchemas::Structs::CrimeApplication do
         expect(
           LaaCrimeSchemas::Validator.new(subject.to_json)
         ).to be_valid
+      end
+
+      it 'has an offence class' do
+        expect(subject.case_details.offence_class).to eq("A")
       end
     end
   end


### PR DESCRIPTION
Adds an offence class virtual attribute to the crime application struct and a offence class trait to calculate the overall offence class of an application for maat integration
[CRIMRE-250](https://dsdmoj.atlassian.net/browse/CRIMRE-250)