### PR TITLE
Allow nino to be either a string or null

### DIFF
--- a/lib/laa_crime_schemas/structs/applicant.rb
+++ b/lib/laa_crime_schemas/structs/applicant.rb
@@ -4,7 +4,7 @@ module LaaCrimeSchemas
   module Structs
     class Applicant < Person
       attribute :date_of_birth, Types::JSON::Date
-      attribute :nino, Types::String
+      attribute? :nino, Types::String
       attribute? :home_address, Address.optional
       attribute? :correspondence_address, Address.optional
       attribute? :telephone_number, Types::String.optional

--- a/schemas/1.0/general/applicant.json
+++ b/schemas/1.0/general/applicant.json
@@ -7,7 +7,7 @@
   "allOf": [{ "$ref": "#/definitions/person" }],
   "properties": {
     "date_of_birth": { "type": "string", "format": "date" },
-    "nino": { "type": "string" },
+    "nino": { "type": ["string", "null"] },
     "telephone_number": { "type": ["string", "null"] },
     "correspondence_address_type": { "type": "string" },
     "home_address": { "$ref": "#/definitions/address" },


### PR DESCRIPTION
Applicants aged under 18 do not need to pass a DWP check and will often not have a nino. This step is now skipped in apply, so nino is not recorded and we shouldn't make it mandatory.