### PR TITLE
Remove unrequired class prefix in offence class data

### DIFF
--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -40,7 +40,7 @@
     "offences": [
       {
         "name": "Attempt robbery",
-        "offence_class": "Class C",
+        "offence_class": "C",
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }

--- a/spec/fixtures/application/1.0/application_completed.json
+++ b/spec/fixtures/application/1.0/application_completed.json
@@ -33,7 +33,7 @@
     "offences": [
       {
         "name": "Attempt robbery",
-        "offence_class": "Class C",
+        "offence_class": "C",
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -32,7 +32,7 @@
     "offences": [
       {
         "name": "Attempt robbery",
-        "offence_class": "Class C",
+        "offence_class": "C",
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }

--- a/spec/fixtures/application/1.0/application_returned_split_case.json
+++ b/spec/fixtures/application/1.0/application_returned_split_case.json
@@ -32,7 +32,7 @@
     "offences": [
       {
         "name": "Attempt robbery",
-        "offence_class": "Class C",
+        "offence_class": "C",
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }


### PR DESCRIPTION
Confirmed on staging that the offence class data is returned without 'Class' prefixed so the fixtures have been amended to reflect that
`#<LaaCrimeSchemas::Structs::Offence name=“Assault a person thereby occasioning them actual bodily harm” offence_class=“C” dates=[#<LaaCrimeSchemas::Structs::Offence::Date date_from=Thu, 10 Jan 1980 date_to=Thu, 10 Jan 1980>]>] irb(main):004:0>`

This change facilitates testing offence class calculation for [CRIMRE-250](https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMRE/boards/960?modal=detail&selectedIssue=CRIMRE-250) in the datastore which uses the fixture data 

[CRIMRE-250]: https://dsdmoj.atlassian.net/browse/CRIMRE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ