### PR TITLE
CRIMAP-331 Add `means_passport` attribute

### DIFF
--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -14,6 +14,7 @@ module LaaCrimeSchemas
       attribute :status, Types::ApplicationStatus
 
       attribute? :ioj_passport, Types::Array.of(Types::IojPassportType).default([].freeze)
+      attribute? :means_passport, Types::Array.of(Types::MeansPassportType).default([].freeze)
 
       attribute :provider_details, Base do
         attribute :office_code, Types::String

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -54,10 +54,15 @@ module LaaCrimeSchemas
 
     IOJ_PASSPORT_TYPES = %w[
       on_age_under18
-      on_case_type
       on_offence
     ].freeze
     IojPassportType = String.enum(*IOJ_PASSPORT_TYPES)
+
+    MEANS_PASSPORT_TYPES = %w[
+      on_age_under18
+      on_benefit_check
+    ].freeze
+    MeansPassportType = String.enum(*MEANS_PASSPORT_TYPES)
 
     RETURN_REASONS = %w[
       clarification_required

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -17,6 +17,10 @@
       "type": "array",
       "items": { "type": "string" }
     },
+    "means_passport": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
     "provider_details": {
       "type": "object",
       "properties": {

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -11,10 +11,6 @@
     "reference": { "type": "number" },
     "submitted_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },
-    "ioj_passport": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
     "provider_details": {
       "type": "object",
       "properties": {

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -7,6 +7,7 @@
   "date_stamp": "2022-10-24T09:50:04.000+00:00",
   "status": "submitted",
   "ioj_passport": [],
+  "means_passport": ["on_benefit_check"],
   "provider_details": {
     "office_code": "1A123B",
     "provider_email": "provider@example.com",
@@ -19,7 +20,7 @@
       "first_name": "Kit",
       "last_name": "Pound",
       "nino": "AJ123456C",
-      "date_of_birth": "2011-06-09",
+      "date_of_birth": "2001-06-09",
       "telephone_number": "07771231231",
       "correspondence_address_type": "home_address",
       "home_address": {

--- a/spec/fixtures/application/1.0/application_completed.json
+++ b/spec/fixtures/application/1.0/application_completed.json
@@ -8,6 +8,7 @@
   "status": "submitted",
   "review_status": "assessment_complete",
   "ioj_passport": ["on_age_under18"],
+  "means_passport": ["on_age_under18"],
   "provider_details": {
     "office_code": "1A123B",
     "provider_email": "provider@example.com",
@@ -20,7 +21,7 @@
       "first_name": "Peter",
       "last_name": "LANDSDALE",
       "nino": "JCT10155B",
-      "date_of_birth": "2003-02-02",
+      "date_of_birth": "2018-02-02",
       "telephone_number": "",
       "correspondence_address_type": "providers_office_address",
       "home_address": null,

--- a/spec/fixtures/application/1.0/application_invalid.json
+++ b/spec/fixtures/application/1.0/application_invalid.json
@@ -7,6 +7,7 @@
   "date_stamp": "2022-10-24T09:50:04.000+00:00",
   "status": "submitted",
   "ioj_passport": [],
+  "means_passport": [],
   "provider_details": {
     "office_code": "1A123B",
     "provider_email": "provider@example.com",

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -6,7 +6,8 @@
   "submitted_at": "2022-09-27T14:10:00.000+00:00",
   "date_stamp": "2022-09-23T16:00:00.000+00:00",
   "status": "returned",
-  "ioj_passport": ["on_age_under18"],
+  "ioj_passport": [],
+  "means_passport": ["on_benefit_check"],
   "provider_details": {
     "office_code": "1A123B",
     "provider_email": "provider@example.com",
@@ -43,7 +44,12 @@
     "hearing_court_name": "Cardiff Magistrates' Court",
     "hearing_date": "2024-11-11"
   },
-  "interests_of_justice": null,
+  "interests_of_justice": [
+    {
+      "type": "loss_of_liberty",
+      "reason": "More details about loss of liberty."
+    }
+  ],
   "return_details": {
     "reason": "clarification_required",
     "details": "Further information regarding IoJ required",

--- a/spec/fixtures/application/1.0/application_returned_split_case.json
+++ b/spec/fixtures/application/1.0/application_returned_split_case.json
@@ -6,7 +6,8 @@
   "submitted_at": "2022-09-27T14:10:00.000+00:00",
   "date_stamp": "2022-09-23T16:00:00.000+00:00",
   "status": "returned",
-  "ioj_passport": [],
+  "ioj_passport": ["on_offence"],
+  "means_passport": ["on_benefit_check"],
   "provider_details": {
     "office_code": "1A123B",
     "provider_email": "provider@example.com",

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -4,7 +4,6 @@
   "reference": 6000001,
   "submitted_at": "2022-10-24T09:50:04.000+00:00",
   "date_stamp": "2022-10-24T09:50:04.000+00:00",
-  "ioj_passport": [],
   "provider_details": {
     "office_code": "1A123B",
     "provider_email": "provider@example.com",

--- a/spec/fixtures/application/1.0/maat_application_invalid.json
+++ b/spec/fixtures/application/1.0/maat_application_invalid.json
@@ -4,7 +4,6 @@
   "reference": 6000001,
   "submitted_at": "2022-10-24T09:50:04.000+00:00",
   "date_stamp": "2022-10-24T09:50:04.000+00:00",
-  "ioj_passport": [],
   "provider_details": {
     "office_code": "1A123B",
     "provider_email": "provider@example.com",


### PR DESCRIPTION
This serves a similar purpose to the already existing `ioj_passport`, so Review can know on what basis an application has been passported on means.

Also, as Apply now handles this more granularly, we need this information back when reading back applications from the datastore and for rehydration.

Existing applications in datastore lack this attribute, so we can either run a migration task or make the code on Apply/Review resilient with a sensible fallback.

Fixtures and schema updated and fixed some logical inconsistencies.