### PR TITLE
Added offence class at case level

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.1.4)
+    laa-criminal-legal-aid-schemas (0.1.6)
       dry-struct
       json-schema (~> 3.0.0)
 
@@ -91,4 +91,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.3.17
+   2.4.12

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -31,6 +31,7 @@ module LaaCrimeSchemas
       attribute :case_details, Base do
         attribute :urn, Types::String.optional
         attribute :case_type, Types::CaseType
+        attribute? :offence_class, Types::OffenceClass.optional
         attribute? :appeal_maat_id, Types::String.optional
         attribute? :appeal_with_changes_maat_id, Types::String.optional
         attribute? :appeal_with_changes_details, Types::String.optional

--- a/lib/laa_crime_schemas/structs/offence.rb
+++ b/lib/laa_crime_schemas/structs/offence.rb
@@ -4,7 +4,7 @@ module LaaCrimeSchemas
   module Structs
     class Offence < Base
       attribute :name, Types::String
-      attribute? :offence_class, Types::OffenceClass.optional
+      attribute? :offence_class, Types::String.optional
       attribute :dates, Types::Array.of(Base).constrained(min_size: 1) do
         attribute :date_from, Types::JSON::Date
         attribute :date_to, Types::JSON::Date.optional

--- a/lib/laa_crime_schemas/structs/offence.rb
+++ b/lib/laa_crime_schemas/structs/offence.rb
@@ -4,7 +4,7 @@ module LaaCrimeSchemas
   module Structs
     class Offence < Base
       attribute :name, Types::String
-      attribute? :offence_class, Types::String.optional
+      attribute? :offence_class, Types::OffenceClass.optional
       attribute :dates, Types::Array.of(Base).constrained(min_size: 1) do
         attribute :date_from, Types::JSON::Date
         attribute :date_to, Types::JSON::Date.optional

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -81,5 +81,8 @@ module LaaCrimeSchemas
       assessment_completed
     ].freeze
     ReviewApplicationStatus = String.enum(*REVIEW_APPLICATION_STATUSES)
+
+    OFFENCE_CLASSES = %w[A K G B I J D C H F E].freeze
+    OffenceClass = String.enum(*OFFENCE_CLASSES)
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.1.4'
+  VERSION = '0.1.6'
 end

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -37,6 +37,7 @@
   "case_details": {
     "urn": "",
     "case_type": "appeal_to_crown_court",
+    "offence_class": null,
     "appeal_maat_id": null,
     "offences": [
       {

--- a/spec/fixtures/application/1.0/application_completed.json
+++ b/spec/fixtures/application/1.0/application_completed.json
@@ -31,6 +31,7 @@
   "case_details": {
     "urn": "12345",
     "case_type": "summary_only",
+    "offence_class": "C",
     "offences": [
       {
         "name": "Attempt robbery",

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -30,6 +30,7 @@
   "case_details": {
     "urn": "12345",
     "case_type": "summary_only",
+    "offence_class": "C",
     "offences": [
       {
         "name": "Attempt robbery",

--- a/spec/fixtures/application/1.0/application_returned_split_case.json
+++ b/spec/fixtures/application/1.0/application_returned_split_case.json
@@ -30,6 +30,7 @@
   "case_details": {
     "urn": "12345",
     "case_type": "summary_only",
+    "offence_class": "C",
     "offences": [
       {
         "name": "Attempt robbery",


### PR DESCRIPTION
## Description of change
Added offence class at case level to allow for persistence of overall offence class to datastore - so that it is not calculated at time of api call. And is also available to Review to surface to the caseworker

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-312

## Additional notes
Overall offence class calculation currently can calculate to nil -> do we want this to be 'Undefined'?
Overall offence class calculation currently outputs offence class as lowercase - can we upcase it?
We were also unable to set this attribute as mandatory because the calculation will not have taken place before the schma validation - is this another argument to calculate overall offence class in Apply?