### PR TITLE
Add test for offence class type

### DIFF
--- a/spec/laa_crime_schemas/types/types_spec.rb
+++ b/spec/laa_crime_schemas/types/types_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe LaaCrimeSchemas::Types do
+  describe 'Types' do
+    context 'for offence class type' do
+      it 'uses a valid offence class ranking' do
+        expect(LaaCrimeSchemas::Types::OffenceClass.values).to eq( %w[A K G B I J D C H F E].freeze)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adding a test for the offence class type to ensure that changes to the offence class ranking (and which may cause breaking changes) are caught in testing as an equivalent test was removed in the datastore repo

## Link to relevant ticket

## Additional notes
