### PR TITLE
CRIMRE-322 require parent_id

### DIFF
--- a/lib/laa_crime_schemas/case_details.rb
+++ b/lib/laa_crime_schemas/case_details.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Structs
+    class CaseDetails < Base
+      attribute :urn, Types::String.optional
+      attribute :case_type, Types::CaseType
+      attribute? :appeal_maat_id, Types::String.optional
+      attribute? :appeal_with_changes_maat_id, Types::String.optional
+      attribute? :appeal_with_changes_details, Types::String.optional
+
+      attribute :offences, Types::Array.of(Offence).constrained(min_size: 1)
+      attribute :codefendants, Types::Array.of(Codefendant).default([].freeze)
+
+      attribute :hearing_court_name, Types::String
+      attribute :hearing_date, Types::JSON::Date
+    end
+  end
+end

--- a/lib/laa_crime_schemas/client_details.rb
+++ b/lib/laa_crime_schemas/client_details.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Structs
+    class ClientDetails < Base
+      attribute :urn, Types::String.optional
+      attribute :case_type, Types::CaseType
+      attribute? :appeal_maat_id, Types::String.optional
+      attribute? :appeal_with_changes_maat_id, Types::String.optional
+      attribute? :appeal_with_changes_details, Types::String.optional
+      attribute :offences, Types::Array.of(Offence).constrained(min_size: 1)
+      attribute :codefendants, Types::Array.of(Codefendant).default([].freeze)
+      attribute :hearing_court_name, Types::String
+      attribute :hearing_date, Types::JSON::Date
+    end
+  end
+end

--- a/lib/laa_crime_schemas/structs/interest_of_justice.rb
+++ b/lib/laa_crime_schemas/structs/interest_of_justice.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Structs
+    class InterestOfJustice < Base
+      attribute :type, Types::IojType
+      attribute :reason, Types::String
+    end
+  end
+end

--- a/lib/laa_crime_schemas/structs/provider_details.rb
+++ b/lib/laa_crime_schemas/structs/provider_details.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Structs
+    class ProviderDetails < Base
+      attribute :office_code, Types::String
+      attribute? :provider_email, Types::String
+      attribute :legal_rep_first_name, Types::String
+      attribute :legal_rep_last_name, Types::String
+      attribute :legal_rep_telephone, Types::String
+    end
+  end
+end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -82,7 +82,7 @@
   },
   "required": [
     "id", "schema_version", "reference", "created_at", "submitted_at", "date_stamp",
-    "provider_details", "client_details", "case_details", "interests_of_justice"
+    "provider_details", "client_details", "case_details", "interests_of_justice", "parent_id"
   ],
   "definitions": {
     "applicant": { "$ref": "general/applicant.json" },

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -2,6 +2,7 @@
   "id": "696dd4fd-b619-4637-ab42-a5f4565bcf4a",
   "schema_version": 1.0,
   "reference": 6000001,
+  "parent_id": null,
   "created_at": "2022-10-24T08:33:04.000+00:00",
   "submitted_at": "2022-10-24T09:50:04.000+00:00",
   "date_stamp": "2022-10-24T09:50:04.000+00:00",

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -2,6 +2,7 @@
   "id": "47a93336-7da6-48ec-b139-808ddd555a41",
   "schema_version": 1.0,
   "reference": 6000002,
+  "parent_id": null,
   "created_at": "2022-09-21T16:25:00.000+00:00",
   "submitted_at": "2022-09-27T14:10:00.000+00:00",
   "date_stamp": "2022-09-23T16:00:00.000+00:00",


### PR DESCRIPTION
A crime application parent_id is required. Failure to require this attribute has allowed the fixtures in this gem to become out-dated and allow a regression in the datastore to go unnoticed.

## Description of change

## Link to relevant ticket

[CRIMRE-322](https://dsdmoj.atlassian.net/browse/CRIMRE-322)

A PR to fix this issue on the datastore will follow.

## Additional notes


[CRIMRE-322]: https://dsdmoj.atlassian.net/browse/CRIMRE-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ