### PR TITLE
[CRIMRE-215] Add enum constraint to correspondence_address_type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.2.0)
+    laa-criminal-legal-aid-schemas (0.1.7)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.1.6)
+    laa-criminal-legal-aid-schemas (0.2.0)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.2.0'
+  VERSION = '0.1.7'
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.1.6'
+  VERSION = '0.2.0'
 end

--- a/schemas/1.0/general/applicant.json
+++ b/schemas/1.0/general/applicant.json
@@ -9,7 +9,7 @@
     "date_of_birth": { "type": "string", "format": "date" },
     "nino": { "type": ["string", "null"] },
     "telephone_number": { "type": ["string", "null"] },
-    "correspondence_address_type": { "type": "string" },
+    "correspondence_address_type": { "type": "string", "enum": ["other_address", "home_address", "providers_office_address"] },
     "home_address": { "$ref": "#/definitions/address" },
     "correspondence_address": { "$ref": "#/definitions/address" }
   },

--- a/spec/laa_crime_schemas/structs/crime_application_spec.rb
+++ b/spec/laa_crime_schemas/structs/crime_application_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe LaaCrimeSchemas::Structs::CrimeApplication do
       end
     end
 
+    context 'for an invalid correspondence_address_type object' do
+      let(:attributes) do
+        json = JSON.parse(file_fixture(invalid_fixture).read)
+        json['client_details']['applicant']['correspondence_address_type'] = 'work_address'
+        json
+      end
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Dry::Struct::Error, /\"work_address\" \(String\) has invalid type/)
+      end
+    end
+
     context 'for a valid returned JSON document' do
       let(:attributes) do
         JSON.parse(file_fixture(returned_fixture).read)


### PR DESCRIPTION
## Description of change
Forces JSON schema constraint for correspondence_address_type to replicate Type/Struct enum constraint for the same field.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMRE-215

## Additional notes
Bump minor version as it's a potential minor breaking change in terms of schema