### PR TITLE
Add `passportable` bool attribute to offence object

### DIFF
--- a/lib/laa_crime_schemas/structs/offence.rb
+++ b/lib/laa_crime_schemas/structs/offence.rb
@@ -4,7 +4,10 @@ module LaaCrimeSchemas
   module Structs
     class Offence < Base
       attribute :name, Types::String
+
       attribute? :offence_class, Types::String.optional
+      attribute? :passportable, Types::Bool
+
       attribute :dates, Types::Array.of(Base).constrained(min_size: 1) do
         attribute :date_from, Types::JSON::Date
         attribute :date_to, Types::JSON::Date.optional

--- a/schemas/1.0/general/offence.json
+++ b/schemas/1.0/general/offence.json
@@ -7,6 +7,7 @@
   "properties": {
     "name": { "type": "string" },
     "offence_class": { "type": ["string", "null"], "enum": ["A", "K", "G", "B", "I", "J", "D", "C", "H", "F", "E", null] },
+    "passportable": { "type": "boolean" },
     "dates": {
       "type": "array",
       "minItems": 1,
@@ -20,5 +21,5 @@
       }
     }
   },
-  "required": ["name", "dates"]
+  "required": ["name", "offence_class", "passportable", "dates"]
 }

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -44,6 +44,7 @@
       {
         "name": "Attempt robbery",
         "offence_class": "C",
+        "passportable": true,
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }
@@ -52,6 +53,7 @@
       {
         "name": "Non-listed offence, manually entered",
         "offence_class": null,
+        "passportable": false,
         "dates": [
           { "date_from": "2020-09-15", "date_to": null }
         ]

--- a/spec/fixtures/application/1.0/application_completed.json
+++ b/spec/fixtures/application/1.0/application_completed.json
@@ -37,6 +37,7 @@
       {
         "name": "Attempt robbery",
         "offence_class": "C",
+        "passportable": true,
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -36,6 +36,7 @@
       {
         "name": "Attempt robbery",
         "offence_class": "C",
+        "passportable": true,
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }

--- a/spec/fixtures/application/1.0/application_returned_split_case.json
+++ b/spec/fixtures/application/1.0/application_returned_split_case.json
@@ -36,6 +36,7 @@
       {
         "name": "Attempt robbery",
         "offence_class": "C",
+        "passportable": true,
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }


### PR DESCRIPTION
## Description of change
On the back of this PR on Apply, we now can propagate this from Apply to Datastore, even tho we don't need it just now.
https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/364

Marking attribute in the Struct as optional, because existing applications in the datastore will not have this.

Not bumping schemas version yet, as there is no need to release a new version just for this.

Will be bumped a bit later once we do some auditing of attributes, structs and schemas that is pending.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-146

## Additional notes
