### PR TITLE
CRIMAP-387 New pruned application schema and struct

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.2.1)
+    laa-criminal-legal-aid-schemas (0.3.0)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/lib/laa_crime_schemas.rb
+++ b/lib/laa_crime_schemas.rb
@@ -21,6 +21,7 @@ require_relative 'laa_crime_schemas/structs/applicant'
 require_relative 'laa_crime_schemas/structs/codefendant'
 require_relative 'laa_crime_schemas/structs/return_details'
 require_relative 'laa_crime_schemas/structs/crime_application'
+require_relative 'laa_crime_schemas/structs/pruned_application'
 
 module LaaCrimeSchemas
   class << self

--- a/lib/laa_crime_schemas/structs/person.rb
+++ b/lib/laa_crime_schemas/structs/person.rb
@@ -7,6 +7,11 @@ module LaaCrimeSchemas
 
       attribute :first_name, Types::String
       attribute :last_name, Types::String
+
+      # This struct is used via composition in other structs
+      # like `codefendant`, `applicant` and potentially in the
+      # future `partner`, and not all of them ask `other_names`,
+      # thus the attribute presence is optional (and value too).
       attribute? :other_names, Types::String.optional
     end
   end

--- a/lib/laa_crime_schemas/structs/pruned_application.rb
+++ b/lib/laa_crime_schemas/structs/pruned_application.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Structs
+    class PrunedApplication < Base
+      attribute :id, Types::String
+      attribute :parent_id, Types::String.optional
+      attribute :schema_version, Types::SchemaVersion
+      attribute :reference, Types::ApplicationReference
+      attribute :application_type, Types::ApplicationType
+      attribute :created_at, Types::JSON::DateTime
+      attribute :submitted_at, Types::JSON::DateTime
+      attribute? :returned_at, Types::JSON::DateTime
+      attribute :status, Types::ApplicationStatus
+
+      attribute :client_details, Base do
+        attribute :applicant, Person
+      end
+    end
+  end
+end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -8,7 +8,7 @@
     "id": { "type": "string" },
     "parent_id": { "type": ["string", "null"] },
     "schema_version": { "type": "number" },
-    "reference": { "type": "number" },
+    "reference": { "type": "integer" },
     "application_type": { "type": "string", "enum": ["initial"] },
     "created_at": { "type": "string", "format": "date-time" },
     "submitted_at": { "type": "string", "format": "date-time" },

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -7,7 +7,7 @@
   "properties": {
     "id": { "type": "string" },
     "schema_version": { "type": "number" },
-    "reference": { "type": "number" },
+    "reference": { "type": "integer" },
     "application_type": { "type": "string", "enum": ["initial"] },
     "submitted_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },

--- a/schemas/1.0/pruned_application.json
+++ b/schemas/1.0/pruned_application.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "ministryofjustice/laa-criminal-legal-aid-schemas/main/schemas/1.0/pruned_application.json",
+  "title": "A pruned application for criminal legal aid",
+  "description": "Attributes of a pruned criminal legal aid application",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "parent_id": { "type": ["string", "null"] },
+    "schema_version": { "type": "number" },
+    "reference": { "type": "integer" },
+    "application_type": { "type": "string", "enum": ["initial"] },
+    "created_at": { "type": "string", "format": "date-time" },
+    "submitted_at": { "type": "string", "format": "date-time" },
+    "returned_at": { "type": "string", "format": "date-time" },
+    "status": { "type": "string", "enum": ["submitted", "returned", "superseded"] },
+    "client_details": {
+      "type": "object",
+      "properties": {
+        "applicant": {
+          "type": "object",
+          "properties": {
+            "first_name": { "type": "string" },
+            "last_name": { "type": "string" }
+          },
+          "required": ["first_name", "last_name"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["applicant"],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "id", "parent_id", "schema_version", "reference", "application_type",
+    "created_at", "submitted_at", "status", "client_details"
+  ],
+  "additionalProperties": false
+}

--- a/spec/fixtures/application/1.0/pruned_application.json
+++ b/spec/fixtures/application/1.0/pruned_application.json
@@ -1,0 +1,17 @@
+{
+  "id": "243487dc-4727-44eb-9c9c-29809c0eb080",
+  "parent_id": null,
+  "schema_version": 1,
+  "reference": 6000118,
+  "application_type": "initial",
+  "created_at": "2023-05-17T08:01:02.490Z",
+  "submitted_at": "2023-06-01T10:36:35.650Z",
+  "returned_at": "2023-06-02T11:45:28.126Z",
+  "status": "returned",
+  "client_details": {
+    "applicant": {
+      "first_name": "John",
+      "last_name": "Doe"
+    }
+  }
+}

--- a/spec/laa_crime_schemas/structs/pruned_application_spec.rb
+++ b/spec/laa_crime_schemas/structs/pruned_application_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe LaaCrimeSchemas::Structs::PrunedApplication do
+  subject { described_class.new(attributes) }
+
+  describe 'schema version 1.0' do
+    let(:fixture) { 'application/1.0/pruned_application.json' }
+
+    context 'for a valid pruned crime application object' do
+      let(:attributes) do
+        JSON.parse(file_fixture(fixture).read)
+      end
+
+      # Just checking an attribute is enough as
+      # if it was invalid it would raise an exception
+      it 'builds a pruned crime application struct' do
+        expect(subject.reference).to eq(6000118)
+      end
+
+      it 'produces a valid JSON document conforming to the schema' do
+        expect(
+          LaaCrimeSchemas::Validator.new(subject.to_json, schema_name: 'pruned_application')
+        ).to be_valid
+      end
+    end
+
+    context 'for an invalid pruned crime application object' do
+      let(:attributes) do
+        json = JSON.parse(file_fixture(fixture).read)
+        json['client_details']['applicant'] = nil
+        json
+      end
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Dry::Struct::Error, /first_name/)
+      end
+    end
+  end
+end

--- a/spec/laa_crime_schemas/validator_spec.rb
+++ b/spec/laa_crime_schemas/validator_spec.rb
@@ -84,6 +84,49 @@ RSpec.describe LaaCrimeSchemas::Validator do
     end
   end
 
+  describe 'pruned application, schema version 1.0' do
+    subject { described_class.new(document, version: version, schema_name: 'pruned_application') }
+
+    let(:valid_fixture) { 'application/1.0/pruned_application.json' }
+
+    describe '#valid?' do
+      context 'when the document is valid' do
+        let(:document) { file_fixture(valid_fixture).read }
+
+        it { expect(subject).to be_valid }
+      end
+
+      context 'when the document is not valid' do
+        let(:document) { { schema_version: 1.0 }.to_json }
+
+        it { expect(subject).not_to be_valid }
+      end
+    end
+
+    describe '#fully_validate' do
+      context 'when the document is valid' do
+        let(:document) { file_fixture(valid_fixture).read }
+
+        it { expect(subject.fully_validate).to be_empty }
+      end
+
+      context 'when the document is not valid' do
+        let(:document) { { schema_version: 1.0 }.to_json }
+
+        it { expect(subject.fully_validate).not_to be_empty }
+      end
+
+      context 'when there are additional unrecognised properties' do
+        let(:document) do
+          json = JSON.parse(file_fixture(valid_fixture).read)
+          json.merge!('case_details' => {})
+        end
+
+        it { expect(subject.fully_validate.to_s).to match(/contains additional properties \[\\\"case_details\\\"\]/) }
+      end
+    end
+  end
+
   describe 'maat application, schema version 1.0' do
     subject { described_class.new(document, version: version, schema_name: 'maat_application') }
 


### PR DESCRIPTION
## Description of change
New struct, schema and fixture corresponding to a simplified, narrowed down, pruned representation of a crime application.

This will contain the basic details needed to present lists of applications to paginate throw them. Usually these lists don't require much detail, mainly status, first name, last name, reference, timestamps, and just in case some additional information about the type of application.

To be used in the datastore, when returning a paginated list of applications. Currently only affects Apply. No changes required for Review.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-387

## Additional notes
PRs to follow for Apply and Datastore.