### PR TITLE
CRIMAP-388 Make the structs more strict

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0.4', '3.1.2']
+        ruby: ['3.2.1', '3.2.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   SuggestExtensions: false
   NewCops: enable
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     laa-criminal-legal-aid-schemas (0.4.0)
-      dry-struct
-      json-schema (~> 3.0.0)
+      dry-struct (~> 1.6.0)
+      json-schema (~> 4.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -35,7 +35,7 @@ GEM
       zeitwerk (~> 2.6)
     ice_nine (0.11.2)
     json (2.6.3)
-    json-schema (3.0.0)
+    json-schema (4.0.0)
       addressable (>= 2.8)
     parallel (1.23.0)
     parser (3.2.2.1)
@@ -58,7 +58,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.51.0)
+    rubocop (1.52.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
@@ -68,7 +68,7 @@ GEM
       rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.1)
+    rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.3.0)
+    laa-criminal-legal-aid-schemas (0.4.0)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/laa-criminal-legal-aid-schemas.gemspec
+++ b/laa-criminal-legal-aid-schemas.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '~> 3.2.1'
 
-  spec.add_runtime_dependency 'dry-struct'
-  spec.add_runtime_dependency 'json-schema', '~> 3.0.0'
+  spec.add_runtime_dependency 'dry-struct', '~> 1.6.0'
+  spec.add_runtime_dependency 'json-schema', '~> 4.0.0'
 end

--- a/lib/laa_crime_schemas.rb
+++ b/lib/laa_crime_schemas.rb
@@ -14,12 +14,17 @@ require_relative 'laa_crime_schemas/traits/full_name'
 require_relative 'laa_crime_schemas/types/types'
 
 require_relative 'laa_crime_schemas/structs/base'
+require_relative 'laa_crime_schemas/structs/base_application'
+
 require_relative 'laa_crime_schemas/structs/offence'
 require_relative 'laa_crime_schemas/structs/address'
 require_relative 'laa_crime_schemas/structs/person'
 require_relative 'laa_crime_schemas/structs/applicant'
 require_relative 'laa_crime_schemas/structs/codefendant'
+require_relative 'laa_crime_schemas/structs/case_details'
+require_relative 'laa_crime_schemas/structs/provider_details'
 require_relative 'laa_crime_schemas/structs/return_details'
+
 require_relative 'laa_crime_schemas/structs/crime_application'
 require_relative 'laa_crime_schemas/structs/pruned_application'
 

--- a/lib/laa_crime_schemas/structs/applicant.rb
+++ b/lib/laa_crime_schemas/structs/applicant.rb
@@ -5,10 +5,10 @@ module LaaCrimeSchemas
     class Applicant < Person
       attribute :date_of_birth, Types::JSON::Date
       attribute :nino, Types::String.optional
-      attribute? :home_address, Address.optional
-      attribute? :correspondence_address, Address.optional
-      attribute? :telephone_number, Types::String.optional
+      attribute :home_address, Address.optional
+      attribute :correspondence_address, Address.optional
       attribute :correspondence_address_type, Types::CorrespondenceAddressType
+      attribute :telephone_number, Types::String.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/base_application.rb
+++ b/lib/laa_crime_schemas/structs/base_application.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Structs
+    class BaseApplication < Base
+      # Basic attributes shared across a `full` application
+      # representation and a `pruned` one. Anything else
+      # should go into their individual structs.
+      #
+      attribute :id, Types::String
+      attribute :parent_id, Types::String.optional
+      attribute :schema_version, Types::SchemaVersion
+      attribute :reference, Types::ApplicationReference
+      attribute :application_type, Types::ApplicationType
+      attribute :status, Types::ApplicationStatus
+
+      attribute :created_at, Types::JSON::DateTime
+      attribute :submitted_at, Types::JSON::DateTime
+      attribute :date_stamp, Types::JSON::DateTime
+      attribute? :returned_at, Types::JSON::DateTime
+    end
+  end
+end

--- a/lib/laa_crime_schemas/structs/case_details.rb
+++ b/lib/laa_crime_schemas/structs/case_details.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Structs
+    class CaseDetails < Base
+      attribute :urn, Types::String.optional
+      attribute :case_type, Types::CaseType
+      attribute? :offence_class, Types::OffenceClass.optional
+      attribute :appeal_maat_id, Types::String.optional
+      attribute :appeal_with_changes_maat_id, Types::String.optional
+      attribute :appeal_with_changes_details, Types::String.optional
+
+      attribute :offences, Types::Array.of(Offence).constrained(min_size: 1)
+      attribute :codefendants, Types::Array.of(Codefendant).default([].freeze)
+
+      attribute :hearing_court_name, Types::String
+      attribute :hearing_date, Types::JSON::Date
+    end
+  end
+end

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -2,46 +2,17 @@
 
 module LaaCrimeSchemas
   module Structs
-    class CrimeApplication < Base
-      attribute :id, Types::String
-      attribute? :parent_id, Types::String.optional
-      attribute :schema_version, Types::SchemaVersion
-      attribute :reference, Types::ApplicationReference
-      attribute? :application_type, Types::ApplicationType # TODO: change attr to required
-      attribute :created_at, Types::JSON::DateTime
-      attribute :submitted_at, Types::JSON::DateTime
-      attribute :date_stamp, Types::JSON::DateTime
-      attribute :status, Types::ApplicationStatus
+    class CrimeApplication < BaseApplication
+      attribute :ioj_passport, Types::Array.of(Types::IojPassportType).default([].freeze)
+      attribute :means_passport, Types::Array.of(Types::MeansPassportType).default([].freeze)
 
-      attribute? :ioj_passport, Types::Array.of(Types::IojPassportType).default([].freeze)
-      attribute? :means_passport, Types::Array.of(Types::MeansPassportType).default([].freeze)
-
-      attribute :provider_details, Base do
-        attribute :office_code, Types::String
-        attribute? :provider_email, Types::String
-        attribute :legal_rep_first_name, Types::String
-        attribute :legal_rep_last_name, Types::String
-        attribute :legal_rep_telephone, Types::String
-      end
+      attribute :provider_details, ProviderDetails
 
       attribute :client_details, Base do
         attribute :applicant, Applicant
       end
 
-      attribute :case_details, Base do
-        attribute :urn, Types::String.optional
-        attribute :case_type, Types::CaseType
-        attribute? :offence_class, Types::OffenceClass.optional
-        attribute? :appeal_maat_id, Types::String.optional
-        attribute? :appeal_with_changes_maat_id, Types::String.optional
-        attribute? :appeal_with_changes_details, Types::String.optional
-
-        attribute :offences, Types::Array.of(Offence).constrained(min_size: 1)
-        attribute :codefendants, Types::Array.of(Codefendant).default([].freeze)
-
-        attribute :hearing_court_name, Types::String
-        attribute :hearing_date, Types::JSON::Date
-      end
+      attribute :case_details, CaseDetails
 
       attribute :interests_of_justice, Types::Coercible::Array.of(Base).default([].freeze) do
         attribute :type, Types::IojType

--- a/lib/laa_crime_schemas/structs/offence.rb
+++ b/lib/laa_crime_schemas/structs/offence.rb
@@ -5,8 +5,8 @@ module LaaCrimeSchemas
     class Offence < Base
       attribute :name, Types::String
 
-      attribute? :offence_class, Types::String.optional
-      attribute? :passportable, Types::Bool
+      attribute :offence_class, Types::OffenceClass.optional
+      attribute :passportable, Types::Bool
 
       attribute :dates, Types::Array.of(Base).constrained(min_size: 1) do
         attribute :date_from, Types::JSON::Date

--- a/lib/laa_crime_schemas/structs/provider_details.rb
+++ b/lib/laa_crime_schemas/structs/provider_details.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Structs
+    class ProviderDetails < Base
+      attribute :office_code, Types::String
+      attribute :provider_email, Types::String
+      attribute :legal_rep_first_name, Types::String
+      attribute :legal_rep_last_name, Types::String
+      attribute :legal_rep_telephone, Types::String
+    end
+  end
+end

--- a/lib/laa_crime_schemas/structs/pruned_application.rb
+++ b/lib/laa_crime_schemas/structs/pruned_application.rb
@@ -2,17 +2,7 @@
 
 module LaaCrimeSchemas
   module Structs
-    class PrunedApplication < Base
-      attribute :id, Types::String
-      attribute :parent_id, Types::String.optional
-      attribute :schema_version, Types::SchemaVersion
-      attribute :reference, Types::ApplicationReference
-      attribute :application_type, Types::ApplicationType
-      attribute :created_at, Types::JSON::DateTime
-      attribute :submitted_at, Types::JSON::DateTime
-      attribute? :returned_at, Types::JSON::DateTime
-      attribute :status, Types::ApplicationStatus
-
+    class PrunedApplication < BaseApplication
       attribute :client_details, Base do
         attribute :applicant, Person
       end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/schemas/1.0/pruned_application.json
+++ b/schemas/1.0/pruned_application.json
@@ -12,6 +12,7 @@
     "application_type": { "type": "string", "enum": ["initial"] },
     "created_at": { "type": "string", "format": "date-time" },
     "submitted_at": { "type": "string", "format": "date-time" },
+    "date_stamp": { "type": "string", "format": "date-time" },
     "returned_at": { "type": "string", "format": "date-time" },
     "status": { "type": "string", "enum": ["submitted", "returned", "superseded"] },
     "client_details": {
@@ -33,7 +34,7 @@
   },
   "required": [
     "id", "parent_id", "schema_version", "reference", "application_type",
-    "created_at", "submitted_at", "status", "client_details"
+    "created_at", "submitted_at", "date_stamp", "status", "client_details"
   ],
   "additionalProperties": false
 }

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -1,5 +1,6 @@
 {
   "id": "696dd4fd-b619-4637-ab42-a5f4565bcf4a",
+  "parent_id": null,
   "schema_version": 1.0,
   "reference": 6000001,
   "application_type": "initial",
@@ -40,6 +41,8 @@
     "case_type": "appeal_to_crown_court",
     "offence_class": null,
     "appeal_maat_id": null,
+    "appeal_with_changes_maat_id": null,
+    "appeal_with_changes_details": null,
     "offences": [
       {
         "name": "Attempt robbery",

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -1,5 +1,6 @@
 {
   "id": "47a93336-7da6-48ec-b139-808ddd555a41",
+  "parent_id": null,
   "schema_version": 1.0,
   "reference": 6000002,
   "application_type": "initial",
@@ -32,6 +33,9 @@
   "case_details": {
     "urn": "12345",
     "case_type": "summary_only",
+    "appeal_maat_id": null,
+    "appeal_with_changes_maat_id": null,
+    "appeal_with_changes_details": null,
     "offence_class": "C",
     "offences": [
       {

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -36,6 +36,8 @@
     "case_type": "appeal_to_crown_court",
     "offence_class": "A",
     "appeal_maat_id": null,
+    "appeal_with_changes_maat_id": null,
+    "appeal_with_changes_details": null,
     "hearing_court_name": "Cardiff Magistrates' Court",
     "hearing_date": "2024-11-11"
   },

--- a/spec/fixtures/application/1.0/pruned_application.json
+++ b/spec/fixtures/application/1.0/pruned_application.json
@@ -1,11 +1,12 @@
 {
   "id": "243487dc-4727-44eb-9c9c-29809c0eb080",
   "parent_id": null,
-  "schema_version": 1,
+  "schema_version": 1.0,
   "reference": 6000118,
   "application_type": "initial",
   "created_at": "2023-05-17T08:01:02.490Z",
   "submitted_at": "2023-06-01T10:36:35.650Z",
+  "date_stamp": "2023-06-01T10:36:35.650Z",
   "returned_at": "2023-06-02T11:45:28.126Z",
   "status": "returned",
   "client_details": {

--- a/spec/laa_crime_schemas/structs/case_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/case_details_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe LaaCrimeSchemas::Structs::CaseDetails do
+  subject { described_class.new(attributes) }
+
+  let(:attributes) do
+    LaaCrimeSchemas.fixture(1.0) { |json| json['case_details'] }
+  end
+
+  describe '.new' do
+    context 'for a valid case details object' do
+      # Just a sanity check to ensure the struct "understands" the JSON object
+      # Offence and Codefendant structs are tested separately
+      it 'builds the case details struct' do
+        expect(subject.urn).to eq('')
+        expect(subject.case_type).to eq('appeal_to_crown_court')
+        expect(subject.appeal_maat_id).to be_nil
+        expect(subject.appeal_with_changes_maat_id).to be_nil
+        expect(subject.appeal_with_changes_details).to be_nil
+        expect(subject.offences.size).to eq(2)
+        expect(subject.codefendants.size).to eq(1)
+        expect(subject.hearing_court_name).to eq("Cardiff Magistrates' Court")
+        expect(subject.hearing_date).to be_a(Date)
+      end
+    end
+
+    context 'for an invalid case details object' do
+      let(:attributes) { super().merge('case_type' => nil) }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Dry::Struct::Error, /case_type/)
+      end
+    end
+  end
+end

--- a/spec/laa_crime_schemas/structs/offence_spec.rb
+++ b/spec/laa_crime_schemas/structs/offence_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe LaaCrimeSchemas::Structs::Offence do
+  subject { described_class.new(attributes) }
+
+  let(:attributes) do
+    LaaCrimeSchemas.fixture(1.0) { |json| json['case_details']['offences'][0] }
+  end
+
+  describe '.new' do
+    context 'for a valid offence object' do
+      it 'builds a codefendant struct' do
+        expect(subject.name).to eq('Attempt robbery')
+        expect(subject.offence_class).to eq('C')
+        expect(subject.passportable).to eq(true)
+
+        expect(subject.dates.size).to eq(2)
+        expect(subject.dates[0].date_from).to be_a(Date)
+        expect(subject.dates[0].date_to).to be_a(Date)
+        expect(subject.dates[1].date_from).to be_a(Date)
+        expect(subject.dates[1].date_to).to be_nil
+      end
+    end
+
+    context 'for an invalid offence object' do
+      let(:attributes) { super().merge('offence_class' => 'X') }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Dry::Struct::Error, /offence_class/)
+      end
+    end
+  end
+end

--- a/spec/laa_crime_schemas/structs/provider_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/provider_details_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe LaaCrimeSchemas::Structs::ProviderDetails do
+  subject { described_class.new(attributes) }
+
+  let(:attributes) do
+    LaaCrimeSchemas.fixture(1.0) { |json| json['provider_details'] }
+  end
+
+  describe '.new' do
+    context 'for a valid provider details object' do
+      it 'builds the provider details struct' do
+        expect(subject.office_code).to eq('1A123B')
+        expect(subject.provider_email).to eq('provider@example.com')
+        expect(subject.legal_rep_first_name).to eq('John')
+        expect(subject.legal_rep_last_name).to eq('Doe')
+        expect(subject.legal_rep_telephone).to eq('123456789')
+      end
+    end
+
+    context 'for an invalid provider details object' do
+      let(:attributes) { super().merge('provider_email' => nil) }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Dry::Struct::Error, /provider_email/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Over the course of the last months we've been evolving the datastore and the submitted JSON documents, with new attributes, or changes to existing ones.

With the objective of not breaking the existing submitted applications every few days, we've been quite lenient in the way the Structs handle the existing data when reading back from the Datastore.

For instance, many attributes were marked as optional, as old data didn't have those. However new submitted applications will always have them now. Etc.

Made changes to the structs to support this. Also a small refactor to the existing structs to have separate `case_details` and `provider_details` and improved testing.

Note these are breaking changes with many of the existing applications in the datastore, so along with this, we would probably want to wipe the DB and start fresh with no baggage.

An additional PR will be raised to the Datastore once the gem new version is tagged.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-388

## Additional notes
