### PR TITLE
CRIMAP-415 Rename `passportable` to `slipstreamable`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.4.0)
+    laa-criminal-legal-aid-schemas (0.5.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/lib/laa_crime_schemas/structs/offence.rb
+++ b/lib/laa_crime_schemas/structs/offence.rb
@@ -6,7 +6,10 @@ module LaaCrimeSchemas
       attribute :name, Types::String
 
       attribute :offence_class, Types::OffenceClass.optional
-      attribute :passportable, Types::Bool
+
+      # Once all applications in datastore have the `slipstreamable`
+      # attribute, we can mark it as mandatory
+      attribute? :slipstreamable, Types::Bool
 
       attribute :dates, Types::Array.of(Base).constrained(min_size: 1) do
         attribute :date_from, Types::JSON::Date

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/schemas/1.0/general/offence.json
+++ b/schemas/1.0/general/offence.json
@@ -7,7 +7,7 @@
   "properties": {
     "name": { "type": "string" },
     "offence_class": { "type": ["string", "null"], "enum": ["A", "K", "G", "B", "I", "J", "D", "C", "H", "F", "E", null] },
-    "passportable": { "type": "boolean" },
+    "slipstreamable": { "type": "boolean" },
     "dates": {
       "type": "array",
       "minItems": 1,
@@ -21,5 +21,5 @@
       }
     }
   },
-  "required": ["name", "offence_class", "passportable", "dates"]
+  "required": ["name", "offence_class", "slipstreamable", "dates"]
 }

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -47,7 +47,7 @@
       {
         "name": "Attempt robbery",
         "offence_class": "C",
-        "passportable": true,
+        "slipstreamable": true,
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }
@@ -56,7 +56,7 @@
       {
         "name": "Non-listed offence, manually entered",
         "offence_class": null,
-        "passportable": false,
+        "slipstreamable": false,
         "dates": [
           { "date_from": "2020-09-15", "date_to": null }
         ]

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -41,7 +41,7 @@
       {
         "name": "Attempt robbery",
         "offence_class": "C",
-        "passportable": true,
+        "slipstreamable": true,
         "dates": [
           { "date_from": "2020-05-11", "date_to": "2020-05-12" },
           { "date_from": "2020-08-11", "date_to": null }

--- a/spec/laa_crime_schemas/structs/offence_spec.rb
+++ b/spec/laa_crime_schemas/structs/offence_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe LaaCrimeSchemas::Structs::Offence do
       it 'builds a codefendant struct' do
         expect(subject.name).to eq('Attempt robbery')
         expect(subject.offence_class).to eq('C')
-        expect(subject.passportable).to eq(true)
+        expect(subject.slipstreamable).to eq(true)
 
         expect(subject.dates.size).to eq(2)
         expect(subject.dates[0].date_from).to be_a(Date)


### PR DESCRIPTION
## Description of change
There will be some changes on Apply to go along with this renaming.

No breaking changes, as the attribute is marked as optional on the Struct object. Also, no consumer was actually using the old attribute.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-415

## Additional notes
