### PR TITLE
CRIMAP-427 Refactor appeal attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.5.0)
+    laa-criminal-legal-aid-schemas (0.6.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/lib/laa_crime_schemas/structs/case_details.rb
+++ b/lib/laa_crime_schemas/structs/case_details.rb
@@ -6,8 +6,10 @@ module LaaCrimeSchemas
       attribute :urn, Types::String.optional
       attribute :case_type, Types::CaseType
       attribute? :offence_class, Types::OffenceClass.optional
+
+      # TODO: mark `appeal_lodged_date` attr as mandatory (keep optional value)
       attribute :appeal_maat_id, Types::String.optional
-      attribute :appeal_with_changes_maat_id, Types::String.optional
+      attribute? :appeal_lodged_date, Types::JSON::Date.optional
       attribute :appeal_with_changes_details, Types::String.optional
 
       attribute :offences, Types::Array.of(Offence).constrained(min_size: 1)

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -39,7 +39,7 @@
         "case_type": { "type": "string", "enum": ["summary_only", "either_way", "indictable", "already_in_crown_court", "committal", "appeal_to_crown_court", "appeal_to_crown_court_with_changes"] },
         "offence_class": { "type": ["string", "null"], "enum": ["A", "K", "G", "B", "I", "J", "D", "C", "H", "F", "E", null] },
         "appeal_maat_id": { "type": ["string", "null"] },
-        "appeal_with_changes_maat_id": { "type": ["string", "null"] },
+        "appeal_lodged_date": { "type": ["string", "null"], "format": "date" },
         "appeal_with_changes_details": { "type": ["string", "null"] },
         "offences": {
           "type": "array",

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -41,7 +41,7 @@
         "urn": { "type": ["string", "null"] },
         "case_type": { "type": "string", "enum": ["summary_only", "either_way", "indictable", "already_in_crown_court", "committal", "appeal_to_crown_court", "appeal_to_crown_court_with_changes"] },
         "appeal_maat_id": { "type": ["string", "null"] },
-        "appeal_with_changes_maat_id": { "type": ["string", "null"] },
+        "appeal_lodged_date": { "type": ["string", "null"], "format": "date" },
         "appeal_with_changes_details": { "type": ["string", "null"] },
         "offence_class": { "type": ["string", "null"], "enum": ["A", "K", "G", "B", "I", "J", "D", "C", "H", "F", "E", null] },
         "hearing_court_name": { "type": "string" },

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -41,7 +41,7 @@
     "case_type": "appeal_to_crown_court",
     "offence_class": null,
     "appeal_maat_id": null,
-    "appeal_with_changes_maat_id": null,
+    "appeal_lodged_date": "2021-10-25",
     "appeal_with_changes_details": null,
     "offences": [
       {

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -34,7 +34,7 @@
     "urn": "12345",
     "case_type": "summary_only",
     "appeal_maat_id": null,
-    "appeal_with_changes_maat_id": null,
+    "appeal_lodged_date": null,
     "appeal_with_changes_details": null,
     "offence_class": "C",
     "offences": [

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -36,7 +36,7 @@
     "case_type": "appeal_to_crown_court",
     "offence_class": "A",
     "appeal_maat_id": null,
-    "appeal_with_changes_maat_id": null,
+    "appeal_lodged_date": "2021-10-25",
     "appeal_with_changes_details": null,
     "hearing_court_name": "Cardiff Magistrates' Court",
     "hearing_date": "2024-11-11"

--- a/spec/laa_crime_schemas/structs/case_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/case_details_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe LaaCrimeSchemas::Structs::CaseDetails do
         expect(subject.urn).to eq('')
         expect(subject.case_type).to eq('appeal_to_crown_court')
         expect(subject.appeal_maat_id).to be_nil
-        expect(subject.appeal_with_changes_maat_id).to be_nil
+        expect(subject.appeal_lodged_date).to be_a(Date)
         expect(subject.appeal_with_changes_details).to be_nil
         expect(subject.offences.size).to eq(2)
         expect(subject.codefendants.size).to eq(1)


### PR DESCRIPTION
## Description of change
Removed no longer needed `appeal_with_changes_maat_id` attribute, because for both types of appeals, the attribute `appeal_maat_id` will be used.

Added a new `appeal_lodged_date` attribute, of type date.

The Struct is not enforcing presence of this new attribute, as existing applications in datastore lack it, but ideally should be made mandatory before going live.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-427

## Additional notes
Just as a sanity check, may I ask review devs to test this gem version in case it breaks something? I think it shouldn't if you were not using before the now removed `appeal_with_changes_maat_id` attribute.