### PR TITLE
Require declaration_signed_at for maat applications

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.6.0)
+    laa-criminal-legal-aid-schemas (0.6.1)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -10,7 +10,7 @@
     "reference": { "type": "integer" },
     "application_type": { "type": "string", "enum": ["initial"] },
     "submitted_at": { "type": "string", "format": "date-time" },
-    "signed_at": { "type": "string", "format": "date-time" },
+    "declaration_signed_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },
     "provider_details": {
       "$ref": "#/definitions/provider"
@@ -56,7 +56,7 @@
     }
   },
   "required": [
-    "id", "schema_version", "reference", "application_type", "submitted_at", "signed_at", "date_stamp",
+    "id", "schema_version", "reference", "application_type", "submitted_at", "declaration_signed_at", "date_stamp",
     "provider_details", "client_details", "case_details", "interests_of_justice"
   ],
   "definitions": {

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -10,6 +10,7 @@
     "reference": { "type": "integer" },
     "application_type": { "type": "string", "enum": ["initial"] },
     "submitted_at": { "type": "string", "format": "date-time" },
+    "signed_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },
     "provider_details": {
       "$ref": "#/definitions/provider"
@@ -55,7 +56,7 @@
     }
   },
   "required": [
-    "id", "schema_version", "reference", "application_type", "submitted_at", "date_stamp",
+    "id", "schema_version", "reference", "application_type", "submitted_at", "signed_at", "date_stamp",
     "provider_details", "client_details", "case_details", "interests_of_justice"
   ],
   "definitions": {

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -4,7 +4,7 @@
   "reference": 6000001,
   "application_type": "initial",
   "submitted_at": "2022-10-24T09:50:04.019Z",
-  "signed_at": "2022-10-24T09:50:04.000+00:00",
+  "declaration_signed_at": "2022-10-24T09:50:04.019Z",
   "date_stamp": "2022-10-24T09:50:04.019Z",
   "provider_details": {
     "office_code": "1A123B",

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -4,6 +4,7 @@
   "reference": 6000001,
   "application_type": "initial",
   "submitted_at": "2022-10-24T09:50:04.019Z",
+  "signed_at": "2022-10-24T09:50:04.000+00:00",
   "date_stamp": "2022-10-24T09:50:04.019Z",
   "provider_details": {
     "office_code": "1A123B",


### PR DESCRIPTION
## Description of change
It was discovered that “date signed” is a mandatory field in MAAT.  This will be provided by us by exposing a `declaration_signed_at` field for maat applications in the datastore. This PR updates the maat application schema to require the attribute. The minor version is also incremented.

## Link to relevant ticket
[CRIMRE-387](https://dsdmoj.atlassian.net/browse/CRIMRE-387)

## Additional notes


[CRIMRE-387]: https://dsdmoj.atlassian.net/browse/CRIMRE-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ