### PR TITLE
[CRIMRE-396] Remove interests_of_justice MAAT property

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.6.1)
+    laa-criminal-legal-aid-schemas (1.0.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.6.1'
+  VERSION = '1.0.0'
 end

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -7,32 +7,28 @@
   "properties": {
     "id": { "type": "string" },
     "schema_version": { "type": "number" },
-    "reference": { "type": "integer" },
-    "application_type": { "type": "string", "enum": ["initial"] },
+    "application_type": { "type": "string" },
+    "reference": { "type": "number" },
     "submitted_at": { "type": "string", "format": "date-time" },
-    "declaration_signed_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },
     "provider_details": {
-      "$ref": "#/definitions/provider"
+      "type": "object",
+      "properties": {
+        "office_code": { "type": "string", "minLength": 1 },
+        "provider_email": { "type": "string" },
+        "legal_rep_first_name": { "type": "string" },
+        "legal_rep_last_name": { "type": "string" },
+        "legal_rep_telephone": { "type": "string" }
+      },
+      "required": [
+        "office_code", "provider_email",
+        "legal_rep_first_name", "legal_rep_last_name", "legal_rep_telephone"
+      ]
     },
     "client_details": {
       "type": "object",
       "properties": {
-        "applicant": {
-          "type": "object",
-          "properties": {
-            "first_name": { "type": "string" },
-            "last_name": { "type": "string" },
-            "other_names": { "type": ["string", "null"] },
-            "date_of_birth": { "type": "string", "format": "date" },
-            "nino": { "type": ["string", "null"] },
-            "telephone_number": { "type": ["string", "null"] },
-            "correspondence_address_type": { "type": "string", "enum": ["other_address", "home_address", "providers_office_address"] },
-            "home_address": { "$ref": "#/definitions/address" },
-            "correspondence_address": { "$ref": "#/definitions/address" }
-          },
-          "required": ["first_name", "last_name", "date_of_birth", "correspondence_address_type"]
-        }
+        "applicant": { "$ref": "#/definitions/applicant" }
       },
       "required": ["applicant"]
     },
@@ -40,28 +36,22 @@
       "type": "object",
       "properties": {
         "urn": { "type": ["string", "null"] },
-        "case_type": { "type": "string", "enum": ["summary_only", "either_way", "indictable", "already_in_crown_court", "committal", "appeal_to_crown_court", "appeal_to_crown_court_with_changes"] },
+        "case_type": { "type": "string" },
         "appeal_maat_id": { "type": ["string", "null"] },
-        "appeal_lodged_date": { "type": ["string", "null"], "format": "date" },
+        "appeal_with_changes_maat_id": { "type": ["string", "null"] },
         "appeal_with_changes_details": { "type": ["string", "null"] },
-        "offence_class": { "type": ["string", "null"], "enum": ["A", "K", "G", "B", "I", "J", "D", "C", "H", "F", "E", null] },
+        "offence_class": { "type": ["string", "null"] },
         "hearing_court_name": { "type": "string" },
         "hearing_date": { "type": "string", "format": "date" }
       },
       "required": ["case_type", "hearing_court_name", "hearing_date", "offence_class"]
-    },
-    "interests_of_justice": {
-      "type": "array",
-      "items": { "$ref": "#/definitions/ioj" }
     }
   },
   "required": [
-    "id", "schema_version", "reference", "application_type", "submitted_at", "declaration_signed_at", "date_stamp",
-    "provider_details", "client_details", "case_details", "interests_of_justice"
+    "id", "schema_version", "reference", "submitted_at", "date_stamp",
+    "provider_details", "client_details", "case_details"
   ],
   "definitions": {
-    "provider": { "$ref": "general/provider.json" },
-    "address": { "$ref": "general/address.json" },
-    "ioj": { "$ref": "general/ioj.json" }
+    "applicant": { "$ref": "general/applicant.json" }
   }
 }

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -53,7 +53,7 @@
   },
   "required": [
     "id", "schema_version", "reference", "application_type", "submitted_at", "declaration_signed_at", "date_stamp",
-    "provider_details", "client_details", "case_details",
+    "provider_details", "client_details", "case_details"
   ],
   "definitions": {
     "provider": { "$ref": "general/provider.json" },

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -7,28 +7,32 @@
   "properties": {
     "id": { "type": "string" },
     "schema_version": { "type": "number" },
-    "application_type": { "type": "string" },
-    "reference": { "type": "number" },
+    "reference": { "type": "integer" },
+    "application_type": { "type": "string", "enum": ["initial"] },
     "submitted_at": { "type": "string", "format": "date-time" },
+    "declaration_signed_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },
     "provider_details": {
-      "type": "object",
-      "properties": {
-        "office_code": { "type": "string", "minLength": 1 },
-        "provider_email": { "type": "string" },
-        "legal_rep_first_name": { "type": "string" },
-        "legal_rep_last_name": { "type": "string" },
-        "legal_rep_telephone": { "type": "string" }
-      },
-      "required": [
-        "office_code", "provider_email",
-        "legal_rep_first_name", "legal_rep_last_name", "legal_rep_telephone"
-      ]
+      "$ref": "#/definitions/provider"
     },
     "client_details": {
       "type": "object",
       "properties": {
-        "applicant": { "$ref": "#/definitions/applicant" }
+        "applicant": {
+          "type": "object",
+          "properties": {
+            "first_name": { "type": "string" },
+            "last_name": { "type": "string" },
+            "other_names": { "type": ["string", "null"] },
+            "date_of_birth": { "type": "string", "format": "date" },
+            "nino": { "type": ["string", "null"] },
+            "telephone_number": { "type": ["string", "null"] },
+            "correspondence_address_type": { "type": "string", "enum": ["other_address", "home_address", "providers_office_address"] },
+            "home_address": { "$ref": "#/definitions/address" },
+            "correspondence_address": { "$ref": "#/definitions/address" }
+          },
+          "required": ["first_name", "last_name", "date_of_birth", "correspondence_address_type"]
+        }
       },
       "required": ["applicant"]
     },
@@ -36,11 +40,11 @@
       "type": "object",
       "properties": {
         "urn": { "type": ["string", "null"] },
-        "case_type": { "type": "string" },
+        "case_type": { "type": "string", "enum": ["summary_only", "either_way", "indictable", "already_in_crown_court", "committal", "appeal_to_crown_court", "appeal_to_crown_court_with_changes"] },
         "appeal_maat_id": { "type": ["string", "null"] },
-        "appeal_with_changes_maat_id": { "type": ["string", "null"] },
+        "appeal_lodged_date": { "type": ["string", "null"], "format": "date" },
         "appeal_with_changes_details": { "type": ["string", "null"] },
-        "offence_class": { "type": ["string", "null"] },
+        "offence_class": { "type": ["string", "null"], "enum": ["A", "K", "G", "B", "I", "J", "D", "C", "H", "F", "E", null] },
         "hearing_court_name": { "type": "string" },
         "hearing_date": { "type": "string", "format": "date" }
       },
@@ -48,10 +52,12 @@
     }
   },
   "required": [
-    "id", "schema_version", "reference", "submitted_at", "date_stamp",
-    "provider_details", "client_details", "case_details"
+    "id", "schema_version", "reference", "application_type", "submitted_at", "declaration_signed_at", "date_stamp",
+    "provider_details", "client_details", "case_details",
   ],
   "definitions": {
-    "applicant": { "$ref": "general/applicant.json" }
+    "provider": { "$ref": "general/provider.json" },
+    "address": { "$ref": "general/address.json" },
+    "ioj": { "$ref": "general/ioj.json" }
   }
 }

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -41,11 +41,5 @@
     "appeal_with_changes_details": null,
     "hearing_court_name": "Cardiff Magistrates' Court",
     "hearing_date": "2024-11-11"
-  },
-  "interests_of_justice": [
-    {
-      "type": "loss_of_liberty",
-      "reason": "More details about loss of liberty."
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Description of change
Removes `interests_of_justice` property for MAAT application schema, but maintains `interests_of_justice` for normal CrimeApplications.

Updates MAJOR version to 1.0.0 as this is a significant breaking change.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-396

## Additional notes
Is this the correct way to remove `IoJ Justification from MAAT` ?

Will require updates to Datastore, Review, Apply Gemfile