### PR TITLE
CRIMAP-433 Refactor return details

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.6.1)
+    laa-criminal-legal-aid-schemas (0.7.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/lib/laa_crime_schemas/structs/return_details.rb
+++ b/lib/laa_crime_schemas/structs/return_details.rb
@@ -5,7 +5,6 @@ module LaaCrimeSchemas
     class ReturnDetails < Base
       attribute :reason, Types::ReturnReason
       attribute :details, Types::String
-      attribute :returned_at, Types::JSON::DateTime
     end
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.6.1'
+  VERSION = '0.7.0'
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -13,6 +13,7 @@
     "created_at": { "type": "string", "format": "date-time" },
     "submitted_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },
+    "returned_at": { "type": "string", "format": "date-time" },
     "status": { "type": "string", "enum": ["submitted", "returned", "superseded"] },
     "ioj_passport": {
       "type": "array",
@@ -63,10 +64,9 @@
       "type": "object",
       "properties": {
         "reason": { "type": "string", "enum": ["clarification_required", "evidence_issue", "duplicate_application", "case_concluded", "provider_request"] },
-        "details": { "type": "string" },
-    	"returned_at": { "type": "string", "format": "date-time" }
+        "details": { "type": "string" }
       },
-      "required": ["reason", "details", "returned_at"]
+      "required": ["reason", "details"]
     }
   },
   "required": [

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -60,7 +60,6 @@
   ],
   "return_details": {
     "reason": "clarification_required",
-    "details": "Further information regarding IoJ required",
-    "returned_at": "2022-09-27T14:10:00.889Z"
+    "details": "Further information regarding IoJ required"
   }
 }

--- a/spec/laa_crime_schemas/structs/return_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/return_details_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe LaaCrimeSchemas::Structs::ReturnDetails do
       it 'builds the return details struct' do
         expect(subject.reason).to eq('clarification_required')
         expect(subject.details).to eq('Further information regarding IoJ required')
-        expect(subject.returned_at.to_s).to eq('2022-09-27T14:10:00+00:00')
       end
     end
 
@@ -33,16 +32,6 @@ RSpec.describe LaaCrimeSchemas::Structs::ReturnDetails do
 
       it 'raises an error' do
         expect { subject }.to raise_error(Dry::Struct::Error, /invalid type for :details/)
-      end
-    end
-
-    context 'with missing returned_at' do
-      let(:attributes) do
-        valid_details.merge(returned_at: nil)
-      end
-
-      it 'raises an error' do
-        expect { subject }.to raise_error(Dry::Struct::Error, /invalid type for :returned_at/)
       end
     end
   end


### PR DESCRIPTION
## Description of change
These small changes in the schema are needed for a bigger piece of work going on in the datastore to remove the ReturnDetails DB table and use instead a jsonb attribute in the existing CrimeApplications DB table.

The `returned_at` attribute in the schema `return_details` object is redundant as this attribute exists as top-level already, so I've removed it.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-433

## Additional notes
