### PR TITLE
CRIMAP-436 MAAT schema changes related to IoJ pass

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (0.7.0)
+    laa-criminal-legal-aid-schemas (0.8.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -12,6 +12,10 @@
     "submitted_at": { "type": "string", "format": "date-time" },
     "declaration_signed_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },
+    "ioj_bypass": {
+      "description": "Indicates whether the Interests of Justice page was skipped or not",
+      "type": "boolean"
+    },
     "provider_details": {
       "$ref": "#/definitions/provider"
     },
@@ -49,19 +53,15 @@
         "hearing_date": { "type": "string", "format": "date" }
       },
       "required": ["case_type", "hearing_court_name", "hearing_date", "offence_class"]
-    },
-    "interests_of_justice": {
-      "type": "array",
-      "items": { "$ref": "#/definitions/ioj" }
     }
   },
   "required": [
-    "id", "schema_version", "reference", "application_type", "submitted_at", "declaration_signed_at", "date_stamp",
-    "provider_details", "client_details", "case_details", "interests_of_justice"
+    "id", "schema_version", "reference", "application_type", "submitted_at",
+    "date_stamp", "declaration_signed_at", "ioj_bypass",
+    "provider_details", "client_details", "case_details"
   ],
   "definitions": {
     "provider": { "$ref": "general/provider.json" },
-    "address": { "$ref": "general/address.json" },
-    "ioj": { "$ref": "general/ioj.json" }
+    "address": { "$ref": "general/address.json" }
   }
 }

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -6,6 +6,7 @@
   "submitted_at": "2022-10-24T09:50:04.019Z",
   "declaration_signed_at": "2022-10-24T09:50:04.019Z",
   "date_stamp": "2022-10-24T09:50:04.019Z",
+  "ioj_bypass": false,
   "provider_details": {
     "office_code": "1A123B",
     "provider_email": "provider@example.com",
@@ -41,11 +42,5 @@
     "appeal_with_changes_details": null,
     "hearing_court_name": "Cardiff Magistrates' Court",
     "hearing_date": "2024-11-11"
-  },
-  "interests_of_justice": [
-    {
-      "type": "loss_of_liberty",
-      "reason": "More details about loss of liberty."
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Description of change
Removed the `interests_of_justice` array object, because MAAT does not need any of its content, and the only purpose of this attribute would have been to check if the array was empty or not, to trigger IoJ pass logic.

This is now explicitly done via a new boolean attribute, `ioj_bypass`, which will be `true` if the Interests of Justice page was skipped on Apply, meaning we didn't gather IoJ reasons, or `false` otherwise. It maps more directly to MAAT business rules and domain.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-436

## Additional notes
A new release will be generated, and changes in datastore are needed, together with this new gem release, to be fully working. Will raise a separate PR in datastore soon.