### PR TITLE
[CRIMAP-580] Add supporting evidence to schema

### DIFF
--- a/lib/laa_crime_schemas.rb
+++ b/lib/laa_crime_schemas.rb
@@ -24,6 +24,7 @@ require_relative 'laa_crime_schemas/structs/codefendant'
 require_relative 'laa_crime_schemas/structs/case_details'
 require_relative 'laa_crime_schemas/structs/provider_details'
 require_relative 'laa_crime_schemas/structs/return_details'
+require_relative 'laa_crime_schemas/structs/document'
 
 require_relative 'laa_crime_schemas/structs/crime_application'
 require_relative 'laa_crime_schemas/structs/pruned_application'

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -19,6 +19,8 @@ module LaaCrimeSchemas
         attribute :reason, Types::String
       end
 
+      attribute :supporting_evidence, Types::Array.of(Document).default([].freeze)
+
       attribute? :return_details, ReturnDetails
     end
   end

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -19,7 +19,7 @@ module LaaCrimeSchemas
         attribute :reason, Types::String
       end
 
-      attribute :supporting_evidence, Types::Array.of(Document).default([].freeze)
+      attribute? :supporting_evidence, Types::Array.of(Document).default([].freeze)
 
       attribute? :return_details, ReturnDetails
     end

--- a/lib/laa_crime_schemas/structs/document.rb
+++ b/lib/laa_crime_schemas/structs/document.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module LaaCrimeSchemas
+  module Structs
+    class Document < Base
+      attribute :s3_object_key, Types::String
+      attribute :filename, Types::String
+      attribute :content_type, Types::String
+      attribute :file_size, Types::Coercible::Integer
+    end
+  end
+end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -72,6 +72,10 @@
       "required": ["reason", "details"]
     }
   },
+  "supporting_evidence": {
+    "type": "array",
+    "items": { "$ref": "#/definitions/document" }
+  },
   "required": [
     "id", "parent_id", "schema_version", "reference", "application_type", "created_at", "submitted_at", "date_stamp",
     "ioj_passport", "means_passport", "provider_details", "client_details", "case_details", "interests_of_justice"
@@ -81,6 +85,7 @@
     "applicant": { "$ref": "general/applicant.json" },
     "codefendant": { "$ref": "general/codefendant.json" },
     "offence": { "$ref": "general/offence.json" },
-    "ioj": { "$ref": "general/ioj.json" }
+    "ioj": { "$ref": "general/ioj.json" },
+    "document": { "$ref": "general/document.json" }
   }
 }

--- a/schemas/1.0/general/document.json
+++ b/schemas/1.0/general/document.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "ministryofjustice/laa-criminal-legal-aid-schemas/main/schemas/1.0/general/document.json",
+  "title": "Document",
+  "description": "Holds attributes of a document",
+  "type": "object",
+  "properties": {
+    "s3_object_key": { "type": ["string", "null"] },
+    "filename": { "type": "string" },
+    "content_type": { "type": "string" },
+    "file_size": { "type": "number" }
+  },
+  "required": ["s3_object_key", "filename", "file_category", "content_type", "file_size"]
+}

--- a/schemas/1.0/general/document.json
+++ b/schemas/1.0/general/document.json
@@ -5,7 +5,7 @@
   "description": "Holds attributes of a document",
   "type": "object",
   "properties": {
-    "s3_object_key": { "type": ["string", "null"] },
+    "s3_object_key": { "type": "string" },
     "filename": { "type": "string" },
     "content_type": { "type": "string" },
     "file_size": { "type": "number" }

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -78,5 +78,13 @@
       "type": "loss_of_liberty",
       "reason": "More details about loss of liberty."
     }
+  ],
+  "supporting_evidence": [
+    {
+      "s3_object_key": "123/abcdef1234",
+      "filename": "test.pdf",
+      "content_type": "application/pdf",
+      "file_size": 12
+    }
   ]
 }

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -62,5 +62,13 @@
   "return_details": {
     "reason": "clarification_required",
     "details": "Further information regarding IoJ required"
-  }
+  },
+  "supporting_evidence": [
+    {
+      "s3_object_key": "123/abcdef1234",
+      "filename": "test.pdf",
+      "content_type": "application/pdf",
+      "file_size": 12
+    }
+  ]
 }

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -44,5 +44,13 @@
     "appeal_with_changes_details": null,
     "hearing_court_name": "Cardiff Magistrates' Court",
     "hearing_date": "2024-11-11"
-  }
+  },
+  "supporting_evidence": [
+    {
+      "s3_object_key": "123/abcdef1234",
+      "filename": "test.pdf",
+      "content_type": "application/pdf",
+      "file_size": 12
+    }
+  ]
 }

--- a/spec/laa_crime_schemas/structs/document_spec.rb
+++ b/spec/laa_crime_schemas/structs/document_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe LaaCrimeSchemas::Structs::Document do
+  subject { described_class.new(attributes) }
+
+  let(:attributes) do
+    LaaCrimeSchemas.fixture(1.0) { |json| json['supporting_evidence'][0] }
+  end
+
+  describe '.new' do
+    context 'for a valid document object' do
+      it 'builds a document struct' do
+        expect(subject.s3_object_key).to eq('123/abcdef1234')
+        expect(subject.filename).to eq('test.pdf')
+        expect(subject.content_type).to eq('application/pdf')
+        expect(subject.file_size).to eq(12)
+      end
+    end
+
+    context 'for an invalid document object' do
+      let(:attributes) { super().merge('filename' => nil) }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Dry::Struct::Error, /filename/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This PR is part of a wider piece of work to serialise application evidence data. In this PR, an initial `supporting_evidence` attribute is added to the application schema. This is an array of documents with four fields (for the time being) `filename`, `s3_object_key` `file_size` `content_type`. The `application`, `application_returned` and `maat_application` fixtures are updated to return the new attribute. 

As the evidence upload work is currently behind a feature flag, the `supporting_evidence` field is not a required attribute.  

## Link to relevant ticket
[CRIMAP-580](
https://dsdmoj.atlassian.net/jira/software/projects/CRIMAP/boards/897?selectedIssue=CRIMAP-580)

## Additional notes
If you would like to test this, see [the apply pr](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/482) for instructions

[CRIMAP-580]: https://dsdmoj.atlassian.net/browse/CRIMAP-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ