### PR TITLE
[CRIMAP-580] Document schema patch

### DIFF
--- a/schemas/1.0/general/document.json
+++ b/schemas/1.0/general/document.json
@@ -10,5 +10,5 @@
     "content_type": { "type": "string" },
     "file_size": { "type": "number" }
   },
-  "required": ["s3_object_key", "filename", "file_category", "content_type", "file_size"]
+  "required": ["s3_object_key", "filename", "content_type", "file_size"]
 }


### PR DESCRIPTION
## Description of change
Removes hangover code where `file_category` was required a document attribute. File category is not being supported for the time being 

## Link to relevant ticket
[CRIMAP-580](https://dsdmoj.atlassian.net/browse/CRIMAP-580)

## Additional notes
