### PR TITLE
Remove supporting evidence from maat application fixture

### DIFF
--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -44,13 +44,5 @@
     "appeal_with_changes_details": null,
     "hearing_court_name": "Cardiff Magistrates' Court",
     "hearing_date": "2024-11-11"
-  },
-  "supporting_evidence": [
-    {
-      "s3_object_key": "123/abcdef1234",
-      "filename": "test.pdf",
-      "content_type": "application/pdf",
-      "file_size": 12
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Description of change
Fixes error in [previous PR](https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/40) where `supporting_evidence` was being returned in the maat application fixture. However, `supporting_evidence` is not being exposed to MAAT

## Link to relevant ticket
[CRIMAP-580](https://dsdmoj.atlassian.net/browse/CRIMAP-580)
## Additional notes


[CRIMAP-580]: https://dsdmoj.atlassian.net/browse/CRIMAP-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ