### PR TITLE
CRIMAP-598 Schema changes to support first court hearing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,21 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.0)
+    laa-criminal-legal-aid-schemas (1.0.3)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    base64 (0.1.1)
     concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    dry-core (1.0.0)
+    dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
     dry-inflector (1.0.0)
@@ -47,7 +48,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.8.1)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -61,7 +62,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.54.2)
+    rubocop (1.56.4)
+      base64 (~> 0.1.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -69,7 +71,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
@@ -81,8 +83,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    unicode-display_width (2.4.2)
-    zeitwerk (2.6.8)
+    unicode-display_width (2.5.0)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby

--- a/lib/laa_crime_schemas/structs/base.rb
+++ b/lib/laa_crime_schemas/structs/base.rb
@@ -6,8 +6,8 @@ module LaaCrimeSchemas
       # convert string keys to symbols
       transform_keys(&:to_sym)
 
-      def to_json(*args)
-        to_h.to_json(*args)
+      def to_json(*)
+        to_h.to_json(*)
       end
     end
   end

--- a/lib/laa_crime_schemas/structs/case_details.rb
+++ b/lib/laa_crime_schemas/structs/case_details.rb
@@ -18,6 +18,9 @@ module LaaCrimeSchemas
 
       attribute :hearing_court_name, Types::String
       attribute :hearing_date, Types::JSON::Date
+
+      attribute? :is_first_court_hearing, Types::FirstHearingAnswerValues.optional
+      attribute? :first_court_hearing_name, Types::String.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -53,6 +53,13 @@ module LaaCrimeSchemas
     ].freeze
     CaseType = String.enum(*CASE_TYPES)
 
+    FIRST_HEARING_ANSWER_VALUES = %w[
+      yes
+      no
+      no_hearing_yet
+    ].freeze
+    FirstHearingAnswerValues = String.enum(*FIRST_HEARING_ANSWER_VALUES)
+
     INTEREST_OF_JUSTICE_TYPES = %w[
       loss_of_liberty
       suspended_sentence

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.0'
+  VERSION = '1.0.3'
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -52,7 +52,9 @@
           "items": { "$ref": "#/definitions/codefendant" }
         },
         "hearing_court_name": { "type": "string" },
-        "hearing_date": { "type": "string", "format": "date" }
+        "hearing_date": { "type": "string", "format": "date" },
+        "is_first_court_hearing": { "type": ["string", "null"], "enum": ["yes", "no", "no_hearing_yet", null] },
+        "first_court_hearing_name": { "type": ["string", "null"] }
       },
       "required": [
         "urn", "case_type", "appeal_maat_id", "appeal_lodged_date", "appeal_with_changes_details",

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -72,7 +72,9 @@
       }
     ],
     "hearing_court_name": "Cardiff Magistrates' Court",
-    "hearing_date": "2024-11-11"
+    "hearing_date": "2024-11-11",
+    "is_first_court_hearing": "no",
+    "first_court_hearing_name": "Bristol Magistrates Court"
   },
   "interests_of_justice": [
     {

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -52,7 +52,9 @@
     ],
     "codefendants": [],
     "hearing_court_name": "Cardiff Magistrates' Court",
-    "hearing_date": "2024-11-11"
+    "hearing_date": "2024-11-11",
+    "is_first_court_hearing": "no",
+    "first_court_hearing_name": "Bristol Magistrates Court"
   },
   "interests_of_justice": [
     {

--- a/spec/laa_crime_schemas/structs/case_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/case_details_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe LaaCrimeSchemas::Structs::CaseDetails do
         expect(subject.codefendants.size).to eq(1)
         expect(subject.hearing_court_name).to eq("Cardiff Magistrates' Court")
         expect(subject.hearing_date).to be_a(Date)
+        expect(subject.is_first_court_hearing).to eq('no')
+        expect(subject.first_court_hearing_name).to eq('Bristol Magistrates Court')
       end
     end
 


### PR DESCRIPTION
## Description of change
Two new optional JSON attributes have been added to the schema. Not added yet to the MAAT schema as, if needed, I'd rather do that as a separate change agreed with them.

Bumped some outdated gems.
Fixed a couple rubocop offences.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-598

## Additional notes
