### PR TITLE
[CRIMAP-650] Add new virus scan attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.3)
+    laa-criminal-legal-aid-schemas (1.0.4)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/lib/laa_crime_schemas/structs/document.rb
+++ b/lib/laa_crime_schemas/structs/document.rb
@@ -7,6 +7,12 @@ module LaaCrimeSchemas
       attribute :filename, Types::String
       attribute :content_type, Types::String
       attribute :file_size, Types::Coercible::Integer
+
+      # Virus scanning
+      attribute :scan_status, Types::VirusScanStatus
+      attribute? :scan_provider, Types::String
+      attribute? :scan_output, Types::String
+      attribute? :scan_at, Types::JSON::Date
     end
   end
 end

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -106,5 +106,18 @@ module LaaCrimeSchemas
 
     OFFENCE_CLASSES = %w[A K G B I J D C H F E].freeze
     OffenceClass = String.enum(*OFFENCE_CLASSES)
+
+    # `awaiting` before a file has been scanned
+    # `incomplete` if virus scan never finished e.g. timeout
+    # `other` for unknown/unsupported scan results
+    VIRUS_SCAN_STATUSES = %w[
+      awaiting
+      pass
+      flagged
+      incomplete
+      other
+    ].freeze
+
+    VirusScanStatus = String.enum(*VIRUS_SCAN_STATUSES)
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end

--- a/schemas/1.0/general/document.json
+++ b/schemas/1.0/general/document.json
@@ -8,7 +8,11 @@
     "s3_object_key": { "type": "string" },
     "filename": { "type": "string" },
     "content_type": { "type": "string" },
-    "file_size": { "type": "number" }
+    "file_size": { "type": "number" },
+    "scan_provider": { "type": "string" },
+    "scan_status": { "type": "string" },
+    "scan_output": { "type": "string" },
+    "scan_at": { "type": "string", "format": "date-time" }
   },
   "required": ["s3_object_key", "filename", "content_type", "file_size"]
 }

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -87,7 +87,9 @@
       "s3_object_key": "123/abcdef1234",
       "filename": "test.pdf",
       "content_type": "application/pdf",
-      "file_size": 12
+      "file_size": 12,
+      "scan_status": "pass",
+      "scan_at": "2023-10-01 12:34:56"
     }
   ]
 }

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -71,7 +71,10 @@
       "s3_object_key": "123/abcdef1234",
       "filename": "test.pdf",
       "content_type": "application/pdf",
-      "file_size": 12
+      "file_size": 12,
+      "scan_status": "flagged",
+      "scan_provider": "ClamAV",
+      "scan_at": "2023-10-01 12:10:00"
     }
   ]
 }

--- a/spec/laa_crime_schemas/structs/document_spec.rb
+++ b/spec/laa_crime_schemas/structs/document_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe LaaCrimeSchemas::Structs::Document do
         expect(subject.filename).to eq('test.pdf')
         expect(subject.content_type).to eq('application/pdf')
         expect(subject.file_size).to eq(12)
+        expect(subject.scan_status).to eq(LaaCrimeSchemas::Types::VirusScanStatus['pass'])
+        expect(subject.scan_at).to be_a(Date)
       end
     end
 
@@ -20,6 +22,14 @@ RSpec.describe LaaCrimeSchemas::Structs::Document do
 
       it 'raises an error' do
         expect { subject }.to raise_error(Dry::Struct::Error, /filename/)
+      end
+    end
+
+    context 'for an invalid virus scan status' do
+      let(:attributes) { super().merge('scan_status' => 'completed') }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Dry::Struct::Error, /scan_status/)
       end
     end
   end


### PR DESCRIPTION
## Description of change
Introduces new document attributes to track virus scan results

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-650

## Additional notes
- is the current `VirusScanStatus` enum values appropriate?
- is this overkill?
- should `scan_provider` be locked down to `ClamAV` and `Other` ? Does anyone care?