### PR TITLE
[CRIMAP-129] Add 'job lost in custody' fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.8)
+    laa-criminal-legal-aid-schemas (1.0.9)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/income_details.rb
+++ b/lib/laa_crime_schemas/structs/income_details.rb
@@ -44,8 +44,8 @@ module LaaCrimeSchemas
 
       attribute? :total, Types::PenceSterling
 
-      attribute :lost_job_in_custody, Types::YesNoValue
-      attribute :date_job_lost, Types::JSON::Date
+      attribute? :lost_job_in_custody, Types::YesNoValue
+      attribute? :date_job_lost, Types::JSON::Date
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/income_details.rb
+++ b/lib/laa_crime_schemas/structs/income_details.rb
@@ -43,6 +43,9 @@ module LaaCrimeSchemas
       end
 
       attribute? :total, Types::PenceSterling
+
+      attribute :lost_job_in_custody, Types::YesNoValue
+      attribute :date_job_lost, Types::JSON::Date
     end
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.8'
+  VERSION = '1.0.9'
 end

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -267,6 +267,13 @@
         },
         "total":{
           "type":"integer"
+        },
+        "lost_job_in_custody":{
+          "type":"string", "enum": ["yes", "no"]
+        },
+        "date_job_lost":{
+          "type":"string",
+          "format":"date"
         }
       },
       "required":[
@@ -326,20 +333,20 @@
               "regular_use":{
                 "anyOf":[
                   {
-                    
+
                   },
                   {
-                    
+
                   }
                 ]
               },
               "purchased_over_three_years_ago":{
                 "anyOf":[
                   {
-                    
+
                   },
                   {
-                    
+
                   }
                 ]
               },

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -84,7 +84,9 @@
   ],
   "means_details": {
     "income_details": {
-      "income_above_threshold": "yes"
+      "income_above_threshold": "yes",
+      "lost_job_in_custody": "yes",
+      "date_job_lost": "2023-09-01"
     }
   },
   "supporting_evidence": [

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -64,7 +64,9 @@
   ],
   "means_details": {
     "income_details": {
-      "income_above_threshold": "yes"
+      "income_above_threshold": "yes",
+      "lost_job_in_custody": "yes",
+      "date_job_lost": "2023-09-01"
     }
   },
   "return_details": {

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -3,30 +3,29 @@
   "employment_status": "employed",
   "income_details": {
     "income_above_threshold": "yes",
-    "benefits": [
-      {"type": "child",
-				"amount": 3990,
-				"frequency": "month"
-			}
-		],
-		"employment_details": {
-			"paye": [
-				{
-					"amount": 1320000,
-					"date": "2023-10-30",
-					"deductions": []
-				}
-			]
-		},
-		"self_employment_details": {
-			"businesses": []
-		},
-		"other_income": [{
-      "type": "other",
-			"amount": 2500,
-			"frequency": "annual",
-			"details": "Book royalty"
-		}],
-    "total": 1370380
-	}
+    "benefits": [{ "type": "child", "amount": 3990, "frequency": "month" }],
+    "employment_details": {
+      "paye": [
+        {
+          "amount": 1320000,
+          "date": "2023-10-30",
+          "deductions": []
+        }
+      ]
+    },
+    "self_employment_details": {
+      "businesses": []
+    },
+    "other_income": [
+      {
+        "type": "other",
+        "amount": 2500,
+        "frequency": "annual",
+        "details": "Book royalty"
+      }
+    ],
+    "total": 1370380,
+    "lost_job_in_custody": "yes",
+    "date_job_lost": "2023-09-01"
+  }
 }


### PR DESCRIPTION
## Description of change
Adds 2 new optional fields:

- `lost_job_in_custody` (yes/no)
- `date_job_lost` (e.g. 2023-10-01)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-129

## Additional notes
PR in contrast to https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/57

Also removes tabs from means.json

Should the 2 new fields be grouped (not grouped at present) e.g.:

```
"lost_job": {
  "lost_job_in_custody": "yes",
  "date_job_lost": "2023-09-01"
}
```

This might be appealing in that both fields (lost_job_in_custody and date_lost_job) must be provided as there must always be a date IF the user has lost_job_in_custody = 'yes'.


