### PR TITLE
[CRIMAP-129] Group lost job fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,7 @@ gem 'rake'
 gem 'rspec'
 gem 'rubocop'
 gem 'simplecov'
+
+group :development, :test do
+  gem 'debug'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.7)
+    laa-criminal-legal-aid-schemas (1.0.9)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,9 @@ GEM
     ast (2.4.2)
     base64 (0.1.1)
     concurrent-ruby (1.2.2)
+    debug (1.8.0)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dry-configurable (1.1.0)
@@ -48,6 +51,10 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     ice_nine (0.11.2)
+    io-console (0.6.0)
+    irb (1.8.3)
+      rdoc
+      reline (>= 0.3.8)
     json (2.6.3)
     json-schema (4.0.0)
       addressable (>= 2.8)
@@ -56,11 +63,17 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    psych (5.1.1.1)
+      stringio
     public_suffix (5.0.3)
     racc (1.7.1)
     rainbow (3.1.1)
     rake (13.0.6)
+    rdoc (6.6.0)
+      psych (>= 4.0.0)
     regexp_parser (2.8.2)
+    reline (0.4.0)
+      io-console (~> 0.5)
     rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -96,6 +109,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    stringio (3.0.8)
     unicode-display_width (2.5.0)
     zeitwerk (2.6.12)
 
@@ -103,6 +117,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  debug
   laa-criminal-legal-aid-schemas!
   rake
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.8)
+    laa-criminal-legal-aid-schemas (1.0.7)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/income_details.rb
+++ b/lib/laa_crime_schemas/structs/income_details.rb
@@ -44,8 +44,10 @@ module LaaCrimeSchemas
 
       attribute? :total, Types::PenceSterling
 
-      attribute? :lost_job_in_custody, Types::YesNoValue
-      attribute? :date_job_lost, Types::JSON::Date
+      attribute? :lost_job do
+        attribute :lost_job_in_custody, Types::YesNoValue
+        attribute :date_job_lost, Types::JSON::Date
+      end
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/income_details.rb
+++ b/lib/laa_crime_schemas/structs/income_details.rb
@@ -44,8 +44,8 @@ module LaaCrimeSchemas
 
       attribute? :total, Types::PenceSterling
 
-      attribute :lost_job_in_custody, Types::YesNoValue
-      attribute :date_job_lost, Types::JSON::Date
+      attribute? :lost_job_in_custody, Types::YesNoValue
+      attribute? :date_job_lost, Types::JSON::Date
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/income_details.rb
+++ b/lib/laa_crime_schemas/structs/income_details.rb
@@ -43,6 +43,9 @@ module LaaCrimeSchemas
       end
 
       attribute? :total, Types::PenceSterling
+
+      attribute :lost_job_in_custody, Types::YesNoValue
+      attribute :date_job_lost, Types::JSON::Date
     end
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.8'
+  VERSION = '1.0.7'
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.7'
+  VERSION = '1.0.9'
 end

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -268,12 +268,21 @@
         "total":{
           "type":"integer"
         },
-        "lost_job_in_custody":{
-          "type":"string", "enum": ["yes", "no"]
-        },
-        "date_job_lost":{
-          "type":"string",
-          "format":"date"
+        "lost_job":{
+          "type":"object",
+          "properties": {
+            "lost_job_in_custody":{
+              "type":"string", "enum": ["yes", "no"]
+            },
+            "date_job_lost":{
+              "type":"string",
+              "format":"date"
+            }
+          },
+          "required": [
+            "lost_job_in_custody",
+            "date_job_lost"
+          ]
         }
       },
       "required":[

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -267,6 +267,13 @@
         },
         "total":{
           "type":"integer"
+        },
+        "lost_job_in_custody":{
+          "type":"string", "enum": ["yes", "no"]
+        },
+        "date_job_lost":{
+          "type":"string",
+          "format":"date"
         }
       },
       "required":[
@@ -326,20 +333,20 @@
               "regular_use":{
                 "anyOf":[
                   {
-                    
+
                   },
                   {
-                    
+
                   }
                 ]
               },
               "purchased_over_three_years_ago":{
                 "anyOf":[
                   {
-                    
+
                   },
                   {
-                    
+
                   }
                 ]
               },

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -84,7 +84,9 @@
   ],
   "means_details": {
     "income_details": {
-      "income_above_threshold": "yes"
+      "income_above_threshold": "yes",
+      "lost_job_in_custody": "yes",
+      "date_job_lost": "2023-09-01"
     }
   },
   "supporting_evidence": [

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -84,9 +84,7 @@
   ],
   "means_details": {
     "income_details": {
-      "income_above_threshold": "yes",
-      "lost_job_in_custody": "yes",
-      "date_job_lost": "2023-09-01"
+      "income_above_threshold": "yes"
     }
   },
   "supporting_evidence": [

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -64,7 +64,9 @@
   ],
   "means_details": {
     "income_details": {
-      "income_above_threshold": "yes"
+      "income_above_threshold": "yes",
+      "lost_job_in_custody": "yes",
+      "date_job_lost": "2023-09-01"
     }
   },
   "return_details": {

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -65,8 +65,10 @@
   "means_details": {
     "income_details": {
       "income_above_threshold": "yes",
-      "lost_job_in_custody": "yes",
-      "date_job_lost": "2023-09-01"
+      "lost_job": {
+        "lost_job_in_custody": "yes",
+        "date_job_lost": "2023-09-01"
+      }
     }
   },
   "return_details": {

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -25,7 +25,9 @@
       }
     ],
     "total": 1370380,
-    "lost_job_in_custody": "yes",
-    "date_job_lost": "2023-09-01"
+    "lost_job": {
+      "lost_job_in_custody": "yes",
+      "date_job_lost": "2023-09-01"
+    }
   }
 }

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -3,30 +3,29 @@
   "employment_status": "employed",
   "income_details": {
     "income_above_threshold": "yes",
-    "benefits": [
-      {"type": "child",
-				"amount": 3990,
-				"frequency": "month"
-			}
-		],
-		"employment_details": {
-			"paye": [
-				{
-					"amount": 1320000,
-					"date": "2023-10-30",
-					"deductions": []
-				}
-			]
-		},
-		"self_employment_details": {
-			"businesses": []
-		},
-		"other_income": [{
-      "type": "other",
-			"amount": 2500,
-			"frequency": "annual",
-			"details": "Book royalty"
-		}],
-    "total": 1370380
-	}
+    "benefits": [{ "type": "child", "amount": 3990, "frequency": "month" }],
+    "employment_details": {
+      "paye": [
+        {
+          "amount": 1320000,
+          "date": "2023-10-30",
+          "deductions": []
+        }
+      ]
+    },
+    "self_employment_details": {
+      "businesses": []
+    },
+    "other_income": [
+      {
+        "type": "other",
+        "amount": 2500,
+        "frequency": "annual",
+        "details": "Book royalty"
+      }
+    ],
+    "total": 1370380,
+    "lost_job_in_custody": "yes",
+    "date_job_lost": "2023-09-01"
+  }
 }


### PR DESCRIPTION
## Description of change
Deliberately group lost job fields rather than leaving them as a flat list of unrelated fields. 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-129

## Additional notes
PR in contrast to https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/56 

Grouping fields may be desirable to force both fields to be provided by the consuming application (Apply) otherwise could end up with dangling data (e.g. `lost_job_in_custody = 'yes'` but `date_job_lost = nil`)

Also introduces `debug` gem to help with debugging.