### PR TITLE
[CRIMAP-246] Make income_details completely optional

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.10)
+    laa-criminal-legal-aid-schemas (1.0.11)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/income_details.rb
+++ b/lib/laa_crime_schemas/structs/income_details.rb
@@ -3,7 +3,7 @@
 module LaaCrimeSchemas
   module Structs
     class IncomeDetails < Base
-      attribute :income_above_threshold, Types::YesNoValue
+      attribute? :income_above_threshold, Types::YesNoValue
 
       attribute? :benefits, Types::Array.of(Base) do
         attribute :type, Types::OtherBenefitType

--- a/lib/laa_crime_schemas/structs/means_details.rb
+++ b/lib/laa_crime_schemas/structs/means_details.rb
@@ -7,7 +7,7 @@ module LaaCrimeSchemas
       # Apply allows applicant to have multiple employment_status
       attribute? :employment_status, Types::EmploymentStatusType
 
-      attribute :income_details, IncomeDetails
+      attribute? :income_details, IncomeDetails
 
       attribute? :capital_details do
         attribute :houses, Types::Array.of(Base) do

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.10'
+  VERSION = '1.0.11'
 end

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -276,9 +276,7 @@
           "format":"date"
         }
       },
-      "required":[
-        "income_above_threshold"
-      ]
+      "required":[]
     },
     "capital_details":{
       "type":"object",


### PR DESCRIPTION
## Description of change
Makes `income_details` fields optional to prevent unforced errors while new features are being developed.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-246

## Additional notes
Caused by Sentry error on staging:
https://ministryofjustice.sentry.io/issues/4673356801/events/bf08339f3e9b41f9a145ca34194dda75/