### PR TITLE
[CRIMAP-224] Add income_tax_rate_above_threshold to Schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.21)
+    laa-criminal-legal-aid-schemas (1.0.22)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/outgoings_details.rb
+++ b/lib/laa_crime_schemas/structs/outgoings_details.rb
@@ -7,6 +7,7 @@ module LaaCrimeSchemas
         attribute :type, Types::OutgoingsType
         attributes_from Amount
       end
+      attribute? :income_tax_rate_above_threshold, Types::YesNoValue.optional
       attribute? :outgoings_more_than_income, Types::YesNoValue.optional
       attribute? :how_manage, Types::String.optional
     end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.21'
+  VERSION = '1.0.22'
 end

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -604,6 +604,17 @@
             ]
           }
         },
+        "income_tax_rate_above_threshold":{
+          "anyOf":[
+            {
+              "type":"null"
+            },
+            {
+              "type":"string",
+              "enum": ["yes", "no"]
+            }
+          ]
+        },
         "outgoings_more_than_income":{
           "anyOf":[
             {

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -97,6 +97,7 @@
       "manage_other_details": "Another way they manage"
     },
     "outgoings_details": {
+      "income_tax_rate_above_threshold": "no",
       "outgoings_more_than_income": "yes",
       "how_manage": "A description of how they manage"
     }

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -72,6 +72,11 @@
       "income_above_threshold": "yes",
       "lost_job_in_custody": "yes",
       "date_job_lost": "2023-09-01"
+    },
+    "outgoings_details": {
+      "income_tax_rate_above_threshold": "yes",
+      "outgoings_more_than_income": null,
+      "how_manage": "Somehow they managed"
     }
   },
   "return_details": {

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -36,6 +36,7 @@
     "total": 1370380
   },
   "outgoings_details": {
+    "income_tax_rate_above_threshold": "no",
     "outgoings_more_than_income": "yes",
     "how_manage": "A description of how they manage"
   }

--- a/spec/laa_crime_schemas/structs/means_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/means_details_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe LaaCrimeSchemas::Structs::MeansDetails do
         expect(struct.employment_status).to eq('employed')
       end
 
-      describe 'storing income details' do 
+      describe 'storing income details' do
         subject(:income_details) { struct.income_details }
 
         it 'includes income total' do
@@ -33,6 +33,10 @@ RSpec.describe LaaCrimeSchemas::Structs::MeansDetails do
       describe 'storing outgoings details' do
         subject(:outgoings_details) { struct.outgoings_details }
 
+        it 'includes income_tax_rate_above_threshold' do
+          expect(outgoings_details.income_tax_rate_above_threshold).to eq('no')
+        end
+
         it 'includes outgoings_more_than_income' do
           expect(outgoings_details.outgoings_more_than_income).to eq('yes')
         end
@@ -45,7 +49,7 @@ RSpec.describe LaaCrimeSchemas::Structs::MeansDetails do
             schema_name:
         )
 
-        expect(validator).to be_valid, validator.fully_validate 
+        expect(validator).to be_valid, validator.fully_validate
       end
     end
   end


### PR DESCRIPTION
## Description of change
Adds new `income_tax_rate_above_threshold` field to `outgoings_details`

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-224

## Additional notes
N/A