### PR TITLE
CRIMAPP-290 add PSE to application type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.24)
+    laa-criminal-legal-aid-schemas (1.0.25)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -17,6 +17,7 @@ module LaaCrimeSchemas
 
     APPLICATION_TYPES = %w[
       initial
+      post_submission_evidence
     ].freeze
     ApplicationType = String.enum(*APPLICATION_TYPES)
 

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -18,6 +18,7 @@ module LaaCrimeSchemas
     APPLICATION_TYPES = %w[
       initial
       post_submission_evidence
+      change_in_financial_circumstances
     ].freeze
     ApplicationType = String.enum(*APPLICATION_TYPES)
 

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.24'
+  VERSION = '1.0.25'
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -9,7 +9,7 @@
     "parent_id": { "type": ["string", "null"] },
     "schema_version": { "type": "number" },
     "reference": { "type": "integer" },
-    "application_type": { "type": "string", "enum": ["initial", "post_submission_evidence"] },
+    "application_type": { "type": "string", "enum": ["initial", "post_submission_evidence", "change_in_financial_circumstances"] },
     "created_at": { "type": "string", "format": "date-time" },
     "submitted_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -9,7 +9,7 @@
     "parent_id": { "type": ["string", "null"] },
     "schema_version": { "type": "number" },
     "reference": { "type": "integer" },
-    "application_type": { "type": "string", "enum": ["initial"] },
+    "application_type": { "type": "string", "enum": ["initial", "post_submission_evidence"] },
     "created_at": { "type": "string", "format": "date-time" },
     "submitted_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -8,7 +8,7 @@
     "id": { "type": "string" },
     "schema_version": { "type": "number" },
     "reference": { "type": "integer" },
-    "application_type": { "type": "string", "enum": ["initial"] },
+    "application_type": { "type": "string", "enum": ["initial", "post_submission_evidence", "change_in_financial_circumstances"] },
     "submitted_at": { "type": "string", "format": "date-time" },
     "declaration_signed_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },

--- a/schemas/1.0/pruned_application.json
+++ b/schemas/1.0/pruned_application.json
@@ -9,7 +9,7 @@
     "parent_id": { "type": ["string", "null"] },
     "schema_version": { "type": "number" },
     "reference": { "type": "integer" },
-    "application_type": { "type": "string", "enum": ["initial"] },
+    "application_type": { "type": "string", "enum": ["initial", "post_submission_evidence", "change_in_financial_circumstances"] },
     "created_at": { "type": "string", "format": "date-time" },
     "submitted_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },


### PR DESCRIPTION
## Description of change
Add PSE and CIFC applications types to schema.

## Link to relevant ticket

[CRIMAPP-87](https://dsdmoj.atlassian.net/browse/CRIMAPP-87)

## Additional notes
As concluded post spike, PSE and CIFC will be stored in the CrimeApplication table.

[CRIMAPP-87]: https://dsdmoj.atlassian.net/browse/CRIMAPP-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ