### PR TITLE
CRIMAPP-290 Add pse fields and make schema more flexible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.25)
+    laa-criminal-legal-aid-schemas (1.0.26)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/base_application.rb
+++ b/lib/laa_crime_schemas/structs/base_application.rb
@@ -16,7 +16,7 @@ module LaaCrimeSchemas
 
       attribute :created_at, Types::JSON::DateTime
       attribute :submitted_at, Types::JSON::DateTime
-      attribute :date_stamp, Types::JSON::DateTime
+      attribute? :date_stamp, Types::JSON::DateTime
       attribute? :returned_at, Types::JSON::DateTime
     end
   end

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -28,7 +28,7 @@ module LaaCrimeSchemas
       attribute? :work_stream, Types::WorkStreamType.optional
 
       attribute? :post_submission_evidence, Types::Array.of(Document).default([].freeze)
-      attribute? :pse_notes, Types::String
+      attribute? :pse_notes, Types::String.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -3,8 +3,8 @@
 module LaaCrimeSchemas
   module Structs
     class CrimeApplication < BaseApplication
-      attribute :ioj_passport, Types::Array.of(Types::IojPassportType).default([].freeze)
-      attribute :means_passport, Types::Array.of(Types::MeansPassportType).default([].freeze)
+      attribute? :ioj_passport, Types::Array.of(Types::IojPassportType).default([].freeze)
+      attribute? :means_passport, Types::Array.of(Types::MeansPassportType).default([].freeze)
 
       attribute :provider_details, ProviderDetails
 
@@ -12,9 +12,9 @@ module LaaCrimeSchemas
         attribute :applicant, Applicant
       end
 
-      attribute :case_details, CaseDetails
+      attribute? :case_details, CaseDetails
 
-      attribute :interests_of_justice, Types::Coercible::Array.of(Base).default([].freeze) do
+      attribute? :interests_of_justice, Types::Coercible::Array.of(Base).default([].freeze) do
         attribute :type, Types::IojType
         attribute :reason, Types::String
       end

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -27,8 +27,7 @@ module LaaCrimeSchemas
 
       attribute? :work_stream, Types::WorkStreamType.optional
 
-      attribute? :post_submission_evidence, Types::Array.of(Document).default([].freeze)
-      attribute? :pse_notes, Types::String.optional
+      attribute? :notes, Types::String.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -26,6 +26,9 @@ module LaaCrimeSchemas
       attribute? :return_details, ReturnDetails
 
       attribute? :work_stream, Types::WorkStreamType.optional
+
+      attribute? :post_submission_evidence, Types::Array.of(Document).default([].freeze)
+      attribute? :pse_notes, Types::String
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/document.rb
+++ b/lib/laa_crime_schemas/structs/document.rb
@@ -7,6 +7,7 @@ module LaaCrimeSchemas
       attribute :filename, Types::String
       attribute :content_type, Types::String
       attribute :file_size, Types::Coercible::Integer
+      attribute? :application_type, Types::String
 
       # Virus scanning
       attribute :scan_status, Types::VirusScanStatus

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.25'
+  VERSION = '1.0.26'
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -81,11 +81,7 @@
     "type": "array",
     "items": { "$ref": "#/definitions/document" }
   },
-  "post_submission_evidence": {
-    "type": "array",
-    "items": { "$ref": "#/definitions/document" }
-  },
-  "pse_notes": { "type": ["string", "null"] },
+  "notes": { "type": ["string", "null"] },
   "work_stream": { "type": ["string", "null"], "enum": ["extradition", "national_crime_team", "criminal_applications_team", null] },
   "required": [
     "id", "parent_id", "schema_version", "reference", "application_type", "created_at", "submitted_at", "date_stamp",

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -85,6 +85,7 @@
     "type": "array",
     "items": { "$ref": "#/definitions/document" }
   },
+  "pse_notes": { "type": ["string", "null"] },
   "work_stream": { "type": ["string", "null"], "enum": ["extradition", "national_crime_team", "criminal_applications_team", null] },
   "required": [
     "id", "parent_id", "schema_version", "reference", "application_type", "created_at", "submitted_at", "date_stamp",

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -81,6 +81,10 @@
     "type": "array",
     "items": { "$ref": "#/definitions/document" }
   },
+  "post_submission_evidence": {
+    "type": "array",
+    "items": { "$ref": "#/definitions/document" }
+  },
   "work_stream": { "type": ["string", "null"], "enum": ["extradition", "national_crime_team", "criminal_applications_team", null] },
   "required": [
     "id", "parent_id", "schema_version", "reference", "application_type", "created_at", "submitted_at", "date_stamp",

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -84,8 +84,8 @@
   "notes": { "type": ["string", "null"] },
   "work_stream": { "type": ["string", "null"], "enum": ["extradition", "national_crime_team", "criminal_applications_team", null] },
   "required": [
-    "id", "parent_id", "schema_version", "reference", "application_type", "created_at", "submitted_at", "date_stamp",
-    "ioj_passport", "means_passport", "provider_details", "client_details", "case_details", "interests_of_justice"
+    "id", "parent_id", "schema_version", "reference", "application_type", "created_at", "submitted_at",
+    "provider_details", "client_details"
   ],
   "definitions": {
     "means": { "$ref": "means.json" },

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -112,6 +112,5 @@
       "scan_at": "2023-10-01 12:34:56"
     }
   ],
-  "notes": "Some kind of note from the provider about this application",
   "work_stream": "criminal_applications_team"
 }

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -112,6 +112,6 @@
       "scan_at": "2023-10-01 12:34:56"
     }
   ],
-  "post_submission_evidence": [],
+  "notes": "Some kind of note from the provider about this application",
   "work_stream": "criminal_applications_team"
 }

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -112,5 +112,6 @@
       "scan_at": "2023-10-01 12:34:56"
     }
   ],
+  "post_submission_evidence": [],
   "work_stream": "criminal_applications_team"
 }

--- a/spec/fixtures/application/1.0/post_submission_evidence.json
+++ b/spec/fixtures/application/1.0/post_submission_evidence.json
@@ -1,0 +1,49 @@
+{
+  "id": "696dd4fd-b619-4637-ab42-a5f4565bcf4a",
+  "parent_id": null,
+  "schema_version": 1.0,
+  "reference": 6000001,
+  "application_type": "initial",
+  "created_at": "2022-10-24T08:33:04.105Z",
+  "submitted_at": "2022-10-24T09:50:04.019Z",
+  "status": "submitted",
+  "provider_details": {
+    "office_code": "1A123B",
+    "provider_email": "provider@example.com",
+    "legal_rep_first_name": "John",
+    "legal_rep_last_name": "Doe",
+    "legal_rep_telephone": "123456789"
+  },
+  "client_details": {
+    "applicant": {
+      "first_name": "Kit",
+      "last_name": "Pound",
+      "other_names": "",
+      "nino": "AJ123456C",
+      "benefit_type": "universal_credit",
+      "date_of_birth": "2001-06-09",
+      "telephone_number": "07771231231",
+      "correspondence_address_type": "home_address",
+      "home_address": {
+        "lookup_id": null,
+        "address_line_one": "1 Road",
+        "address_line_two": "Village",
+        "city": "Some nice city",
+        "country": "United Kingdom",
+        "postcode": "SW1A 2AA"
+      },
+      "correspondence_address": null
+    }
+  },
+  "supporting_evidence": [
+    {
+      "s3_object_key": "123/abcdef1234",
+      "filename": "test.pdf",
+      "content_type": "application/pdf",
+      "file_size": 12,
+      "scan_at": "2023-10-01 12:34:56"
+    }
+  ],
+  "notes": "Some kind of note from the provider about this application",
+  "work_stream": "criminal_applications_team"
+}


### PR DESCRIPTION
## Description of change
As part of the work to introduce post submission evidence functionality to apply and review, some crime application fields that were previously mandatory have now been made optional fields. 

This makes the schema more flexible in anticipation for new application types being added in the future (e.g. change in financial circumstances) that do not require fields like a `case_type` or `date_stamp`

Also adds a notes field to collect notes as part of a pse application and a fixture for a post submission evidence application for testing in apply

## Link to relevant ticket

[CRIMAPP-290](https://dsdmoj.atlassian.net/browse/CRIMAPP-290)

## Additional notes


[CRIMAPP-290]: https://dsdmoj.atlassian.net/browse/CRIMAPP-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ