### PR TITLE
[CRIMAPP-290] Amend fixtures for pse testing

### DIFF
--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -109,7 +109,8 @@
       "filename": "test.pdf",
       "content_type": "application/pdf",
       "file_size": 12,
-      "scan_at": "2023-10-01 12:34:56"
+      "scan_at": "2023-10-01 12:34:56",
+      "application_type": "initial"
     }
   ],
   "work_stream": "criminal_applications_team"

--- a/spec/fixtures/application/1.0/post_submission_evidence.json
+++ b/spec/fixtures/application/1.0/post_submission_evidence.json
@@ -1,9 +1,9 @@
 {
-  "id": "696dd4fd-b619-4637-ab42-a5f4565bcf4a",
-  "parent_id": null,
+  "id": "21c37e3e-520f-46f1-bd1f-5c25ffc57d70",
+  "parent_id": "696dd4fd-b619-4637-ab42-a5f4565bcf4a",
   "schema_version": 1.0,
   "reference": 6000001,
-  "application_type": "initial",
+  "application_type": "post_submission_evidence",
   "created_at": "2022-10-24T08:33:04.105Z",
   "submitted_at": "2022-10-24T09:50:04.019Z",
   "status": "submitted",
@@ -41,7 +41,8 @@
       "filename": "test.pdf",
       "content_type": "application/pdf",
       "file_size": 12,
-      "scan_at": "2023-10-01 12:34:56"
+      "scan_at": "2023-10-01 12:34:56",
+      "application_type": "post_submission_evidence"
     }
   ],
   "notes": "Some kind of note from the provider about this application",


### PR DESCRIPTION
## Description of change
Small changes to fixture files for PSE testing. Assigns a unique id to the pse application fixture and adds the `application_id` of the standard initial application as the `parent_id` of the pse application. Also adds the `application_type` to the relevant fields 

## Link to relevant ticket

## Additional notes
