### PR TITLE
CRIMAPP-356 Add reviewed_at to structs and schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.27)
+    laa-criminal-legal-aid-schemas (1.0.28)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/base_application.rb
+++ b/lib/laa_crime_schemas/structs/base_application.rb
@@ -18,6 +18,7 @@ module LaaCrimeSchemas
       attribute :submitted_at, Types::JSON::DateTime
       attribute? :date_stamp, Types::JSON::DateTime
       attribute? :returned_at, Types::JSON::DateTime
+      attribute? :reviewed_at, Types::JSON::DateTime
     end
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.27'
+  VERSION = '1.0.28'
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -13,8 +13,9 @@
     "created_at": { "type": "string", "format": "date-time" },
     "submitted_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },
-    "returned_at": { "type": "string", "format": "date-time" },
-    "status": { "type": "string", "enum": ["submitted", "returned", "superseded"] },
+    "returned_at": { "type": "string", "format": "date-time", "readOnly": true },
+    "reviewed_at": { "type": "string", "format": "date-time", "readOnly": true },
+    "status": { "type": "string", "enum": ["submitted", "returned", "superseded"], "readOnly": true },
     "ioj_passport": {
       "type": "array",
       "items": { "type": "string", "enum": ["on_age_under18", "on_offence"] }

--- a/schemas/1.0/pruned_application.json
+++ b/schemas/1.0/pruned_application.json
@@ -14,6 +14,7 @@
     "submitted_at": { "type": "string", "format": "date-time" },
     "date_stamp": { "type": "string", "format": "date-time" },
     "returned_at": { "type": "string", "format": "date-time" },
+    "reviewed_at": { "type": "string", "format": "date-time" },
     "status": { "type": "string", "enum": ["submitted", "returned", "superseded"] },
     "client_details": {
       "type": "object",


### PR DESCRIPTION
## Description of Change
Add "reviewed_at" to the schema and structs.

## Link to Relevant Ticket
[CRIMAPP-356](https://dsdmoj.atlassian.net/browse/CRIMAPP-356)

## Additional Notes

To determine when to display the PSE link, Apply needs to know whether an application has been reviewed. In our initial spike, we used the "review_status", but now we prefer "reviewed_at" as it discloses less internal Review information. Additionally, this update includes the addition of a "readOnly" flag to attributes owned by the datastore on the application schema. Note: the "readOnly" flag is not applied to the pruned schema, as this schema is entirely readOnly.

[CRIMAPP-356]: https://dsdmoj.atlassian.net/browse/CRIMAPP-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ