### PR TITLE
Remove application_type from document

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.28)
+    laa-criminal-legal-aid-schemas (1.0.29)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/document.rb
+++ b/lib/laa_crime_schemas/structs/document.rb
@@ -7,7 +7,6 @@ module LaaCrimeSchemas
       attribute :filename, Types::String
       attribute :content_type, Types::String
       attribute :file_size, Types::Coercible::Integer
-      attribute? :application_type, Types::String
 
       # Virus scanning
       attribute :scan_status, Types::VirusScanStatus

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.28'
+  VERSION = '1.0.29'
 end

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -109,8 +109,7 @@
       "filename": "test.pdf",
       "content_type": "application/pdf",
       "file_size": 12,
-      "scan_at": "2023-10-01 12:34:56",
-      "application_type": "initial"
+      "scan_at": "2023-10-01 12:34:56"
     }
   ],
   "work_stream": "criminal_applications_team"

--- a/spec/fixtures/application/1.0/post_submission_evidence.json
+++ b/spec/fixtures/application/1.0/post_submission_evidence.json
@@ -41,8 +41,7 @@
       "filename": "test.pdf",
       "content_type": "application/pdf",
       "file_size": 12,
-      "scan_at": "2023-10-01 12:34:56",
-      "application_type": "post_submission_evidence"
+      "scan_at": "2023-10-01 12:34:56"
     }
   ],
   "notes": "Some kind of note from the provider about this application",


### PR DESCRIPTION
## Description of change

Application type is no longer required on documents

## Link to relevant ticket

## Additional notes
This presence of 'application_type' on documents was causing a breaking change on current Apply.