### PR TITLE
reviewed_at, returned_at, and date_stamp can all be null

### DIFF
--- a/lib/laa_crime_schemas/structs/base_application.rb
+++ b/lib/laa_crime_schemas/structs/base_application.rb
@@ -16,9 +16,9 @@ module LaaCrimeSchemas
 
       attribute :created_at, Types::JSON::DateTime
       attribute :submitted_at, Types::JSON::DateTime
-      attribute? :date_stamp, Types::JSON::DateTime
-      attribute? :returned_at, Types::JSON::DateTime
-      attribute? :reviewed_at, Types::JSON::DateTime
+      attribute? :date_stamp, Types::JSON::DateTime.optional
+      attribute? :returned_at, Types::JSON::DateTime.optional
+      attribute? :reviewed_at, Types::JSON::DateTime.optional
     end
   end
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -12,9 +12,9 @@
     "application_type": { "type": "string", "enum": ["initial", "post_submission_evidence", "change_in_financial_circumstances"] },
     "created_at": { "type": "string", "format": "date-time" },
     "submitted_at": { "type": "string", "format": "date-time" },
-    "date_stamp": { "type": "string", "format": "date-time" },
-    "returned_at": { "type": "string", "format": "date-time", "readOnly": true },
-    "reviewed_at": { "type": "string", "format": "date-time", "readOnly": true },
+    "date_stamp": { "type": ["string", "null"], "format": "date-time" },
+    "returned_at": { "type": ["string", "null"], "format": "date-time", "readOnly": true },
+    "reviewed_at": { "type": ["string", "null"], "format": "date-time", "readOnly": true },
     "status": { "type": "string", "enum": ["submitted", "returned", "superseded"], "readOnly": true },
     "ioj_passport": {
       "type": "array",

--- a/schemas/1.0/pruned_application.json
+++ b/schemas/1.0/pruned_application.json
@@ -12,9 +12,9 @@
     "application_type": { "type": "string", "enum": ["initial", "post_submission_evidence", "change_in_financial_circumstances"] },
     "created_at": { "type": "string", "format": "date-time" },
     "submitted_at": { "type": "string", "format": "date-time" },
-    "date_stamp": { "type": "string", "format": "date-time" },
-    "returned_at": { "type": "string", "format": "date-time" },
-    "reviewed_at": { "type": "string", "format": "date-time" },
+    "date_stamp": { "type": ["string", "null"], "format": "date-time" },
+    "returned_at": { "type": ["string", "null"], "format": "date-time" },
+    "reviewed_at": { "type": ["string", "null"], "format": "date-time" },
     "status": { "type": "string", "enum": ["submitted", "returned", "superseded"] },
     "client_details": {
       "type": "object",

--- a/spec/laa_crime_schemas/structs/pruned_application_spec.rb
+++ b/spec/laa_crime_schemas/structs/pruned_application_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe LaaCrimeSchemas::Structs::PrunedApplication do
 
   describe 'schema version 1.0' do
     let(:fixture) { 'application/1.0/pruned_application.json' }
+    let(:validator) { LaaCrimeSchemas::Validator.new(subject.to_json, schema_name: 'pruned_application') }
 
     context 'for a valid pruned crime application object' do
       let(:attributes) do
@@ -16,9 +17,7 @@ RSpec.describe LaaCrimeSchemas::Structs::PrunedApplication do
       end
 
       it 'produces a valid JSON document conforming to the schema' do
-        expect(
-          LaaCrimeSchemas::Validator.new(subject.to_json, schema_name: 'pruned_application')
-        ).to be_valid
+        expect(validator).to be_valid, validator.fully_validate
       end
     end
 


### PR DESCRIPTION
## Description of Change
The fields `reviewed_at`, `returned_at`, and `date_stamp` are now allowed to be null.

## Link to Relevant Ticket
[CRIMAPP-356](https://dsdmoj.atlassian.net/browse/CRIMAPP-356)

## Additional Notes
With the introduction of PSE, `date_stamp` is now permitted to be null in the schema. Additionally, the schema now allows for `reviewed_at` and `returned_at` to be present and null. This oversight was tolerated due to submitted applications not validating against the JSON schema.

I have not update the release version for this change.


[CRIMAPP-356]: https://dsdmoj.atlassian.net/browse/CRIMAPP-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ