### PR TITLE
Rename 'notes' 'additional_information'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.31)
+    laa-criminal-legal-aid-schemas (1.0.32)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -27,7 +27,7 @@ module LaaCrimeSchemas
 
       attribute? :work_stream, Types::WorkStreamType.optional
 
-      attribute? :notes, Types::String.optional
+      attribute? :additional_information, Types::String.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.31'
+  VERSION = '1.0.32'
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -84,7 +84,7 @@
     "type": "array",
     "items": { "$ref": "#/definitions/document" }
   },
-  "notes": { "type": ["string", "null"] },
+  "additional_information": { "type": ["string", "null"] },
   "work_stream": { "type": ["string", "null"], "enum": ["extradition", "national_crime_team", "criminal_applications_team", null] },
   "required": [
     "id", "parent_id", "schema_version", "reference", "application_type", "created_at", "submitted_at",

--- a/spec/fixtures/application/1.0/post_submission_evidence.json
+++ b/spec/fixtures/application/1.0/post_submission_evidence.json
@@ -44,6 +44,6 @@
       "scan_at": "2023-10-01 12:34:56"
     }
   ],
-  "notes": "Some kind of note from the provider about this application",
+  "additional_information": "Some kind of note from the provider about this application",
   "work_stream": "criminal_applications_team"
 }


### PR DESCRIPTION
## Description of change
Rename 'notes' 'additional_information'

## Link to relevant ticket

## Additional notes
We used 'notes' in the spike but 'additional_information' matches the domain better. No production services use 'notes'
