### PR TITLE
CRIMAPP-310 Allow null for has_case_concluded

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.32)
+    laa-criminal-legal-aid-schemas (1.0.33)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/case_details.rb
+++ b/lib/laa_crime_schemas/structs/case_details.rb
@@ -13,7 +13,7 @@ module LaaCrimeSchemas
       attribute :appeal_lodged_date, Types::JSON::Date.optional
       attribute :appeal_with_changes_details, Types::String.optional
 
-      attribute? :has_case_concluded, Types::String
+      attribute? :has_case_concluded, Types::YesNoValue.optional
       attribute? :date_case_concluded, Types::JSON::Date.optional
 
       attribute :offences, Types::Array.of(Offence).constrained(min_size: 1)

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.32'
+  VERSION = '1.0.33'
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -46,7 +46,7 @@
         "appeal_maat_id": { "type": ["string", "null"] },
         "appeal_lodged_date": { "type": ["string", "null"], "format": "date" },
         "appeal_with_changes_details": { "type": ["string", "null"] },
-        "has_case_concluded": { "type": ["string", "null"], "enum": ["yes", "no"] },
+        "has_case_concluded": { "type": ["string", "null"], "enum": ["yes", "no", null] },
         "date_case_concluded": { "type": ["string", "null"], "format": "date" },
         "offences": {
           "type": "array",

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -46,7 +46,7 @@
         "appeal_maat_id": { "type": ["string", "null"] },
         "appeal_lodged_date": { "type": ["string", "null"], "format": "date" },
         "appeal_with_changes_details": { "type": ["string", "null"] },
-        "has_case_concluded": { "type": ["string", "null"], "enum": ["yes", "no", null] },
+        "has_case_concluded": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "date_case_concluded": { "type": ["string", "null"], "format": "date" },
         "offences": {
           "type": "array",

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -46,7 +46,7 @@
         "appeal_maat_id": { "type": ["string", "null"] },
         "appeal_lodged_date": { "type": ["string", "null"], "format": "date" },
         "appeal_with_changes_details": { "type": ["string", "null"] },
-        "has_case_concluded": { "type": ["string"], "enum": ["yes", "no"] },
+        "has_case_concluded": { "type": ["string", "null"], "enum": ["yes", "no"] },
         "date_case_concluded": { "type": ["string", "null"], "format": "date" },
         "offences": {
           "type": "array",


### PR DESCRIPTION
## Description of change
Allow null for `cases.has_case_concluded` attribute to support old applications

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-310

## Additional notes
