### PR TITLE
CRIMAPP-314 Add is_client_remanded attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.34)
+    laa-criminal-legal-aid-schemas (1.0.35)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/case_details.rb
+++ b/lib/laa_crime_schemas/structs/case_details.rb
@@ -16,6 +16,9 @@ module LaaCrimeSchemas
       attribute? :has_case_concluded, Types::YesNoValue.optional
       attribute? :date_case_concluded, Types::JSON::Date.optional
 
+      attribute? :is_client_remanded, Types::YesNoValue.optional
+      attribute? :date_client_remanded, Types::JSON::Date.optional
+
       attribute :offences, Types::Array.of(Offence).constrained(min_size: 1)
       attribute :codefendants, Types::Array.of(Codefendant).default([].freeze)
 

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.34'
+  VERSION = '1.0.35'
 end

--- a/schemas/1.0/application.json
+++ b/schemas/1.0/application.json
@@ -48,6 +48,8 @@
         "appeal_with_changes_details": { "type": ["string", "null"] },
         "has_case_concluded": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "date_case_concluded": { "type": ["string", "null"], "format": "date" },
+        "is_client_remanded": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
+        "date_client_remanded": { "type": ["string", "null"], "format": "date" },
         "offences": {
           "type": "array",
           "minItems": 1,

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -43,6 +43,8 @@
     "case_type": "appeal_to_crown_court",
     "has_case_concluded": "no",
     "date_case_concluded": null,
+    "is_client_remanded": "no",
+    "date_client_remanded": null,
     "offence_class": null,
     "appeal_maat_id": null,
     "appeal_lodged_date": "2021-10-25",

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -41,6 +41,8 @@
     "case_type": "summary_only",
     "has_case_concluded": "no",
     "date_case_concluded": null,
+    "is_client_remanded": "no",
+    "date_client_remanded": null,
     "appeal_maat_id": null,
     "appeal_lodged_date": null,
     "appeal_with_changes_details": null,


### PR DESCRIPTION
## Description of change

Add `is_client_remanded` attributes
Add `is_client_remanded` and the `date_client_remanded` to struct, schema and fixtures

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-314

## Additional notes
This change is required for [laa-apply-for-criminal-legal-aid](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid) specs to pass
