### PR TITLE
[CRIMAPP-218] Add case reference field for outgoings misc payments

### DIFF
--- a/lib/laa_crime_schemas/structs/amount.rb
+++ b/lib/laa_crime_schemas/structs/amount.rb
@@ -8,6 +8,7 @@ module LaaCrimeSchemas
 
       attribute? :metadata do
         attribute? :details, Types::String.optional
+        attribute? :case_reference, Types::String.optional
       end
     end
   end

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -89,12 +89,15 @@ module LaaCrimeSchemas
                                     ])
 
     OutgoingsType = String.enum(*%w[
-                                  housing
+                                  rent
+                                  mortgage
+                                  board_and_lodging
                                   council_tax
                                   childcare
                                   maintenance
-                                  legal_aid
+                                  legal_aid_contribution
                                 ])
+
     HOUSING_PAYMENT_TYPES = %w[
       rent
       mortgage

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -582,14 +582,16 @@
           "items":{
             "type":"object",
             "properties":{
-              "type":{
+              "payment_type":{
                 "type":"string",
                 "enum":[
-                  "housing",
+                  "rent",
+                  "mortgage",
+                  "board_and_lodging",
                   "council_tax",
                   "childcare",
                   "maintenance",
-                  "legal_aid"
+                  "legal_aid_contribution"
                 ]
               },
               "amount":{
@@ -605,19 +607,21 @@
                   "annual"
                 ]
               },
-              "details":{
-                "anyOf":[
-                  {
-                    "type":"null"
+              "metadata":{
+                "type":"object",
+                "properties":{
+                  "details":{
+                    "anyOf": [{ "type":"null" }, { "type":"string" }]
                   },
-                  {
-                    "type":"string"
+                  "case_reference":{
+                    "anyOf": [{ "type":"null" }, { "type":"string" }]
                   }
-                ]
+                },
+                "required": []
               }
             },
             "required":[
-              "type",
+              "payment_type",
               "amount",
               "frequency"
             ]
@@ -630,7 +634,7 @@
             },
             {
               "type":"string",
-              "enum": ["rent", "mortgage", "board_lodgings", "none"]
+              "enum": ["rent", "mortgage", "board_and_lodging", "none"]
             }
           ]
         },

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -56,6 +56,19 @@
     "housing_payment_type": "rent",
     "income_tax_rate_above_threshold": "no",
     "outgoings_more_than_income": "yes",
-    "how_manage": "A description of how they manage"
+    "how_manage": "A description of how they manage",
+    "outgoings": [
+      {
+        "payment_type": "childcare",
+        "amount": 98281,
+        "frequency": "week"
+      },
+      {
+        "payment_type": "legal_aid_contribution",
+        "amount": 1234,
+        "frequency": "week",
+        "metadata": { "case_reference": "CASE1234" }
+      }
+    ]
   }
 }

--- a/spec/laa_crime_schemas/structs/means_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/means_details_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe LaaCrimeSchemas::Structs::MeansDetails do
         it 'includes outgoings_more_than_income' do
           expect(outgoings_details.outgoings_more_than_income).to eq('yes')
         end
+
+        context 'with outgoing payments' do
+          let(:outgoing_payment_1) { outgoings_details.outgoings[0] }
+          let(:outgoing_payment_2) { outgoings_details.outgoings[1] }
+
+          it 'allows valid data' do
+            expect(outgoing_payment_1.payment_type).to eq 'childcare'
+            expect(outgoing_payment_1.amount).to eq 98281
+            expect(outgoing_payment_1.frequency).to eq 'week'
+          end
+
+          it 'allows case reference' do
+            expect(outgoing_payment_2.payment_type).to eq 'legal_aid_contribution'
+            expect(outgoing_payment_2.metadata.case_reference).to eq 'CASE1234'
+          end
+        end
       end
 
       it 'produces a valid JSON document conforming to the schema' do


### PR DESCRIPTION
## Description of change
Adds `metadata.case_reference` to `Amount` to allow Outgoing payments

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-218

## Additional notes
Outgoing types have been updated to match Apply but will need clarifying