### PR TITLE
Consistent names for ownership

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.46)
+    laa-criminal-legal-aid-schemas (1.0.47)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/investment.rb
+++ b/lib/laa_crime_schemas/structs/investment.rb
@@ -6,7 +6,7 @@ module LaaCrimeSchemas
       attribute :investment_type, Types::InvestmentType
       attribute :description, Types::String
       attribute :value, Types::PenceSterling
-      attribute :holder, Types::OwnershipType
+      attribute :ownership_type, Types::OwnershipType
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/saving.rb
+++ b/lib/laa_crime_schemas/structs/saving.rb
@@ -10,7 +10,7 @@ module LaaCrimeSchemas
       attribute :account_number, Types::String
       attribute :is_overdrawn, Types::YesNoValue
       attribute :are_wages_paid_into_account, Types::YesNoValue
-      attribute :account_holder, Types::OwnershipType
+      attribute :ownership_type, Types::OwnershipType
     end
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.46'
+  VERSION = '1.0.47'
 end

--- a/schemas/1.0/general/investment.json
+++ b/schemas/1.0/general/investment.json
@@ -8,7 +8,7 @@
     "investment_type": { "type": ["string"], "enum": ["bond", "pep", "share_isa", "stock", "unit_trust", "other"] },
     "description": { "type": "string" },
     "value": { "type": "integer" },
-    "holder": { "type": ["string"], "enum": ["applicant", "applicant_and_partner", "partner"] }
+    "ownership_type": { "type": ["string"], "enum": ["applicant", "applicant_and_partner", "partner"] }
   },
-  "required": ["investment_type", "value", "description", "holder"]
+  "required": ["investment_type", "value", "description", "ownership_type"]
 }

--- a/schemas/1.0/general/saving.json
+++ b/schemas/1.0/general/saving.json
@@ -12,7 +12,7 @@
     "account_number": { "type": "string" },
     "is_overdrawn": { "type": "string", "enum": ["yes", "no"] },
     "are_wages_paid_into_account": { "type": "string", "enum": ["yes", "no"] },
-    "account_holder": { "type": ["string"], "enum": ["applicant", "applicant_and_partner", "partner"] }
+    "ownership_type": { "type": ["string"], "enum": ["applicant", "applicant_and_partner", "partner"] }
   },
-  "required": ["saving_type", "provider_name", "account_balance", "sort_code", "account_number", "is_overdrawn", "are_wages_paid_into_account", "account_holder"]
+  "required": ["saving_type", "provider_name", "account_balance", "sort_code", "account_number", "is_overdrawn", "are_wages_paid_into_account", "ownership_type"]
 }

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -96,7 +96,7 @@
         "account_balance": 200,
         "is_overdrawn": "yes",
         "are_wages_paid_into_account": "yes",
-        "account_holder": "applicant"
+        "ownership_type": "applicant"
       }
     ],
     "investments": [
@@ -104,7 +104,7 @@
         "investment_type": "unit_trust",
         "description": "Details of investment",
         "value": 200,
-        "holder": "partner"
+        "ownership_type": "partner"
       }
     ]
   }

--- a/spec/laa_crime_schemas/structs/investment_spec.rb
+++ b/spec/laa_crime_schemas/structs/investment_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe LaaCrimeSchemas::Structs::Investment do
         expect(subject.investment_type).to eq('unit_trust')
         expect(subject.description).to eq('Details of investment')
         expect(subject.value).to eq(200)
-        expect(subject.holder).to eq('partner')
+        expect(subject.ownership_type).to eq('partner')
       end
     end
 

--- a/spec/laa_crime_schemas/structs/saving_spec.rb
+++ b/spec/laa_crime_schemas/structs/saving_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe LaaCrimeSchemas::Structs::Saving do
         expect(subject.account_balance).to eq(200)
         expect(subject.is_overdrawn).to eq('yes')
         expect(subject.are_wages_paid_into_account).to eq('yes')
-        expect(subject.account_holder).to eq('applicant')
+        expect(subject.ownership_type).to eq('applicant')
       end
     end
 


### PR DESCRIPTION
## Description of change
Savings, Investments and other assets were storing ownership_type on different attributes (holder, account_holder etc).

## Link to relevant ticket

## Additional notes
