### PR TITLE
[CRIMAPP-586] Add trust fund attributes to schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.48)
+    laa-criminal-legal-aid-schemas (1.0.49)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/capital_details.rb
+++ b/lib/laa_crime_schemas/structs/capital_details.rb
@@ -7,6 +7,10 @@ module LaaCrimeSchemas
       attribute :premium_bonds_total_value, Types::PenceSterling.optional
       attribute :premium_bonds_holder_number, Types::String.optional
 
+      attribute :will_benefit_from_trust_fund, Types::YesNoValue
+      attribute :trust_fund_amount_held, Types::PenceSterling.optional
+      attribute :yearly_dividend, Types::PenceSterling.optional
+
       attribute? :savings, Types::Array.of(Saving).default([].freeze)
       attribute? :properties, Types::Array.of(Property).default([].freeze)
       attribute? :investments, Types::Array.of(Investment).default([].freeze)

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.48'
+  VERSION = '1.0.49'
 end

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -392,6 +392,9 @@
       	"has_premium_bonds":{"type":"string", "enum": ["yes", "no"]},
         "premium_bonds_total_value":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "premium_bonds_holder_number":{"anyOf":[{ "type":"null" }, { "type":"string" }]},
+        "will_benefit_from_trust_fund":{"type":"string", "enum": ["yes", "no"]},
+        "trust_fund_amount_held":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
+        "yearly_dividend":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "savings": {
           "type": "array",
           "items": { "$ref": "#/definitions/saving" }

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -409,7 +409,7 @@
         }
       },
       "required":[
-        "has_premium_bonds", "savings", "properties"
+        "has_premium_bonds", "savings", "properties", "investments"
       ]
     },
     "outgoings_details":{

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -87,6 +87,9 @@
     "has_premium_bonds": "no",
     "premium_bonds_total_value": null,
     "premium_bonds_holder_number": null,
+    "will_benefit_from_trust_fund": "no",
+    "trust_fund_amount_held": null,
+    "yearly_dividend": null,
     "savings": [
       {
         "saving_type": "bank",

--- a/spec/laa_crime_schemas/structs/capital_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/capital_details_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe LaaCrimeSchemas::Structs::CapitalDetails do
         expect(subject.has_premium_bonds).to eq('no')
         expect(subject.premium_bonds_total_value).to be_nil
         expect(subject.premium_bonds_holder_number).to be_nil
+        expect(subject.will_benefit_from_trust_fund).to eq('no')
+        expect(subject.trust_fund_amount_held).to be_nil
+        expect(subject.yearly_dividend).to be_nil
         expect(subject.savings.size).to eq(1)
         expect(subject.investments.size).to eq(1)
         expect(subject.properties.size).to eq(1)
@@ -107,6 +110,101 @@ RSpec.describe LaaCrimeSchemas::Structs::CapitalDetails do
     
       context 'when attribute is missing' do
         let(:attributes) { super().except(key) }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(Dry::Struct::Error, /#{key}/)
+        end
+      end
+    end
+
+    describe '#will_benefit_from_trust_fund' do
+      let(:key) { 'will_benefit_from_trust_fund' }
+      subject(:value) { struct.send(key) }
+
+      context 'when nil' do
+        let(:attributes) { super().merge(key => nil) }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(Dry::Struct::Error, /#{key}/)
+        end
+      end
+
+      context 'when not a yes/no' do
+        let(:attributes) { super().merge('will_benefit_from_trust_fund' => 'NotYesOrNo') }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(Dry::Struct::Error, /#{key}/)
+        end
+      end
+
+      context 'when attribute is missing' do
+        let(:attributes) { super().except(key) }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(Dry::Struct::Error, /#{key}/)
+        end
+      end
+    end
+
+    describe '#trust_fund_amount_held' do
+      let(:key) { 'trust_fund_amount_held' }
+      subject(:value) { struct.send(key) }
+
+      context 'when attribute is missing' do
+        let(:attributes) { super().except(key) }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(Dry::Struct::Error, /#{key}/)
+        end
+      end
+
+      context 'when an integer' do
+        let(:attributes) { super().merge(key => 123100) }
+
+        it { is_expected.to be 123100 }
+      end
+
+      context 'when nil' do
+        let(:attributes) { super().merge(key => nil) }
+
+        it { is_expected.to be nil }
+      end
+
+      context 'when not an integer' do
+        let(:attributes) { super().merge(key => '1231.00') }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(Dry::Struct::Error, /#{key}/)
+        end
+      end
+    end
+
+    describe '#yearly_dividend' do
+      let(:key) { 'yearly_dividend' }
+      subject(:value) { struct.send(key) }
+
+      context 'when attribute is missing' do
+        let(:attributes) { super().except(key) }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(Dry::Struct::Error, /#{key}/)
+        end
+      end
+
+      context 'when an integer' do
+        let(:attributes) { super().merge(key => 123100) }
+
+        it { is_expected.to be 123100 }
+      end
+
+      context 'when nil' do
+        let(:attributes) { super().merge(key => nil) }
+
+        it { is_expected.to be nil }
+      end
+
+      context 'when not an integer' do
+        let(:attributes) { super().merge(key => '1231.00') }
 
         it 'raises an error' do
           expect { subject }.to raise_error(Dry::Struct::Error, /#{key}/)


### PR DESCRIPTION
## Description of change
Add trust fund attributes to capital details

## Link to relevant ticket
[CRIMAPP-586](https://dsdmoj.atlassian.net/browse/CRIMAPP-586)

## Additional notes


[CRIMAPP-586]: https://dsdmoj.atlassian.net/browse/CRIMAPP-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ