### PR TITLE
Add frozen income assets savings attribute to capital details

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.51)
+    laa-criminal-legal-aid-schemas (1.0.52)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/capital_details.rb
+++ b/lib/laa_crime_schemas/structs/capital_details.rb
@@ -9,7 +9,7 @@ module LaaCrimeSchemas
 
       attribute? :will_benefit_from_trust_fund, Types::YesNoValue
       attribute? :trust_fund_amount_held, Types::PenceSterling.optional
-      attribute? :yearly_dividend, Types::PenceSterling.optional
+      attribute? :trust_fund_yearly_dividend, Types::PenceSterling.optional
 
       attribute? :savings, Types::Array.of(Saving).default([].freeze)
       attribute? :properties, Types::Array.of(Property).default([].freeze)

--- a/lib/laa_crime_schemas/structs/capital_details.rb
+++ b/lib/laa_crime_schemas/structs/capital_details.rb
@@ -15,6 +15,8 @@ module LaaCrimeSchemas
       attribute? :properties, Types::Array.of(Property).default([].freeze)
       attribute? :investments, Types::Array.of(Investment).default([].freeze)
       attribute? :national_savings_certificates, Types::Array.of(NationalSavingsCertificate).default([].freeze)
+
+      attribute? :has_frozen_income_or_assets, Types::YesNoValue.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.51'
+  VERSION = '1.0.52'
 end

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -394,7 +394,7 @@
         "premium_bonds_holder_number":{"anyOf":[{ "type":"null" }, { "type":"string" }]},
         "will_benefit_from_trust_fund":{"type":"string", "enum": ["yes", "no"]},
         "trust_fund_amount_held":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
-        "yearly_dividend":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
+        "trust_fund_yearly_dividend":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "savings": {
           "type": "array",
           "items": { "$ref": "#/definitions/saving" }

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -153,7 +153,7 @@
       "premium_bonds_holder_number": "123568A",
       "will_benefit_from_trust_fund": "yes",
       "trust_fund_amount_held": 100000,
-      "yearly_dividend": 200000,
+      "trust_fund_yearly_dividend": 200000,
       "savings": [
         {
           "saving_type": "bank",

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -202,7 +202,8 @@
             "country": "country_x",
             "postcode": "postcode_x" }
         }
-      ]
+      ],
+      "has_frozen_income_or_assets": null
     }
   },
   "supporting_evidence": [

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -138,6 +138,7 @@
           "country": "country_x",
           "postcode": "postcode_x" }
       }
-    ]
+    ],
+    "has_frozen_income_or_assets": null
   }
 }

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -89,7 +89,7 @@
     "premium_bonds_holder_number": "123568A",
     "will_benefit_from_trust_fund": "yes",
     "trust_fund_amount_held": 100000,
-    "yearly_dividend": 200000,
+    "trust_fund_yearly_dividend": 200000,
     "savings": [
       {
         "saving_type": "bank",

--- a/spec/laa_crime_schemas/structs/capital_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/capital_details_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe LaaCrimeSchemas::Structs::CapitalDetails do
         expect(subject.premium_bonds_holder_number).to eq('123568A')
         expect(subject.will_benefit_from_trust_fund).to eq('yes')
         expect(subject.trust_fund_amount_held).to eq(100_000)
-        expect(subject.yearly_dividend).to eq(200_000)
+        expect(subject.trust_fund_yearly_dividend).to eq(200_000)
         expect(subject.savings.size).to eq(1)
         expect(subject.investments.size).to eq(1)
         expect(subject.properties.size).to eq(1)
@@ -140,8 +140,8 @@ RSpec.describe LaaCrimeSchemas::Structs::CapitalDetails do
       end
     end
 
-    describe '#yearly_dividend' do
-      let(:key) { 'yearly_dividend' }
+    describe '#trust_fund_yearly_dividend' do
+      let(:key) { 'trust_fund_yearly_dividend' }
       subject(:value) { struct.send(key) }
 
       context 'when an integer' do


### PR DESCRIPTION
## Description of change
Also renames `yearly_dividend` to `trust_fund_yearly_dividend`

## Link to relevant ticket
[CRIMAPP-505](https://dsdmoj.atlassian.net/browse/CRIMAPP-505)

## Additional notes


[CRIMAPP-505]: https://dsdmoj.atlassian.net/browse/CRIMAPP-505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ