### PR TITLE
Rename keys to income_benefits and income_payments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.56)
+    laa-criminal-legal-aid-schemas (1.0.58)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.56'
+  VERSION = '1.0.58'
 end

--- a/schemas/1.0/maat/means.json
+++ b/schemas/1.0/maat/means.json
@@ -8,12 +8,55 @@
     "income_details":{
       "type":"object",
       "properties":{
-        "benefits":{
+        "income_payments":{
           "type":"array",
           "items":{
             "type":"object",
             "properties":{
-              "type":{
+              "payment_type":{
+                "type":"string",
+                "enum":[
+                  "private_pension",
+                  "state_pension",
+                  "maintenance",
+                  "interest",
+                  "student",
+                  "board_from_family",
+                  "rent",
+                  "friends_and_family",
+                  "other"
+                ]
+              },
+              "amount":{
+                "type":"integer"
+              },
+              "frequency":{
+                "type":"string",
+                "enum":[
+                  "week",
+                  "fortnight",
+                  "four_weeks",
+                  "month",
+                  "annual"
+                ]
+              },
+              "details":{
+                "type":"string"
+              }
+            },
+            "required":[
+              "payment_type",
+              "amount",
+              "frequency"
+            ]
+          }
+        },
+        "income_benefits":{
+          "type":"array",
+          "items":{
+            "type":"object",
+            "properties":{
+              "payment_type":{
                 "type":"string",
                 "enum":[
                   "child",
@@ -39,18 +82,11 @@
                 ]
               },
               "details":{
-                "anyOf":[
-                  {
-                    "type":"null"
-                  },
-                  {
-                    "type":"string"
-                  }
-                ]
+                "type":"string"
               }
             },
             "required":[
-              "type",
+              "payment_type",
               "amount",
               "frequency"
             ]
@@ -213,56 +249,6 @@
             "paye"
           ]
         },
-        "other_income":{
-          "type":"array",
-          "items":{
-            "type":"object",
-            "properties":{
-              "type":{
-                "type":"string",
-                "enum":[
-                  "private_pension",
-                  "state_pension",
-                  "maintenance",
-                  "interest",
-                  "student",
-                  "board_from_family",
-                  "rent",
-                  "friends_and_family",
-                  "other"
-                ]
-              },
-              "amount":{
-                "type":"integer"
-              },
-              "frequency":{
-                "type":"string",
-                "enum":[
-                  "week",
-                  "fortnight",
-                  "four_weeks",
-                  "month",
-                  "annual"
-                ]
-              },
-              "details":{
-                "anyOf":[
-                  {
-                    "type":"null"
-                  },
-                  {
-                    "type":"string"
-                  }
-                ]
-              }
-            },
-            "required":[
-              "type",
-              "amount",
-              "frequency"
-            ]
-          }
-        },
         "total":{
           "type":"integer"
         },
@@ -292,14 +278,16 @@
           "items":{
             "type":"object",
             "properties":{
-              "type":{
+              "payment_type":{
                 "type":"string",
                 "enum":[
-                  "housing",
+                  "rent",
+                  "mortgage",
+                  "board_and_lodging",
                   "council_tax",
                   "childcare",
                   "maintenance",
-                  "legal_aid"
+                  "legal_aid_contribution"
                 ]
               },
               "amount":{
@@ -314,35 +302,14 @@
                   "month",
                   "annual"
                 ]
-              },
-              "details":{
-                "anyOf":[
-                  {
-                    "type":"null"
-                  },
-                  {
-                    "type":"string"
-                  }
-                ]
               }
             },
             "required":[
-              "type",
+              "payment_type",
               "amount",
               "frequency"
             ]
           }
-        },
-        "housing_payment_type":{
-          "anyOf":[
-            {
-              "type":"null"
-            },
-            {
-              "type":"string",
-              "enum": ["rent", "mortgage", "board_and_lodging", "none"]
-            }
-          ]
         }
       },
       "required":[]

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -109,14 +109,16 @@
         {
           "payment_type": "board_from_family",
           "amount": 1603,
-          "frequency": "week"
+          "frequency": "week",
+          "metadata": {}
         }
       ],
       "income_benefits": [
         {
           "payment_type": "child",
           "amount": 3990,
-          "frequency": "month"
+          "frequency": "month",
+          "metadata": {}
         },
         {
           "payment_type": "other",
@@ -139,7 +141,8 @@
         {
           "payment_type": "childcare",
           "amount": 98281,
-          "frequency": "week"
+          "frequency": "week",
+          "metadata": {}
         },
         {
           "payment_type": "legal_aid_contribution",

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -48,13 +48,6 @@
   },
   "means_details": {
     "income_details": {
-      "benefits": [
-        {
-          "type": "universal_credit",
-          "amount": 400,
-          "frequency": "month"
-        }
-      ],
       "employment_type": ["not_working"],
       "employment_details": {
         "paye": [],
@@ -64,11 +57,30 @@
         },
         "businesses": []
       },
-      "other_income": [
+      "income_payments": [
         {
-          "type": "friends_and_family",
+          "payment_type": "friends_and_family",
           "amount": 300,
           "frequency": "month"
+        },
+        {
+          "payment_type": "other",
+          "amount": 250,
+          "frequency": "month",
+          "details": "Details of the other payment"
+        }
+      ],
+      "income_benefits": [
+        {
+          "payment_type": "universal_credit",
+          "amount": 400,
+          "frequency": "month"
+        },
+        {
+          "payment_type": "other",
+          "amount": 800,
+          "frequency": "month",
+          "details": "Details of the other benefit"
         }
       ],
       "total": 1000,
@@ -77,12 +89,11 @@
     "outgoings_details": {
       "outgoings": [
         {
-          "type": "housing",
+          "payment_type": "rent",
           "amount": 700,
           "frequency": "month"
         }
-      ],
-     "housing_payment_type": "mortgage"
+      ]
     }
   }
 }

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -13,7 +13,8 @@
       {
         "payment_type": "child",
         "amount": 3990,
-        "frequency": "month"
+        "frequency": "month",
+        "metadata": {}
       },
       {
         "payment_type": "other",
@@ -32,7 +33,8 @@
       {
         "payment_type": "board_from_family",
         "amount": 1603,
-        "frequency": "week"
+        "frequency": "week",
+        "metadata": {}
       }
     ],
     "dependants": [{"age": 1}, {"age":  5}],
@@ -62,7 +64,8 @@
       {
         "payment_type": "childcare",
         "amount": 98281,
-        "frequency": "week"
+        "frequency": "week",
+        "metadata": {}
       },
       {
         "payment_type": "legal_aid_contribution",

--- a/spec/laa_crime_schemas/structs/means_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/means_details_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe LaaCrimeSchemas::Structs::MeansDetails do
             expect(income_benefit.payment_type).to eq 'child'
             expect(income_benefit.amount).to eq 3990
             expect(income_benefit.frequency).to eq 'month'
-            expect(income_benefit.metadata).to be_nil
+            expect(income_benefit.metadata).to be_a LaaCrimeSchemas::Structs::Amount::Metadata
           end
         end
       end


### PR DESCRIPTION
## Description of change
Rename some keys and values on MAAT schema and fixture to align with current naming:
`benefits` > `income_benefits`
`other_income` > `income_payments`
`type` > `payment_type`
`legal_aid` > `legal_aid_contribution`
Remove housing outgoing payment enum `housing` and add `rent`/`mortgage`/`board_and_lodging`

Remove `housing_payment_type` from MAAT a this is now captured in the object in the outgoings array and needless to send
## Link to relevant ticket

## Additional notes
