### PR TITLE
CRIMAPP-506 Add support for has_no_other_assets in capital

### DIFF
--- a/lib/laa_crime_schemas/structs/capital_details.rb
+++ b/lib/laa_crime_schemas/structs/capital_details.rb
@@ -17,6 +17,7 @@ module LaaCrimeSchemas
       attribute? :national_savings_certificates, Types::Array.of(NationalSavingsCertificate).default([].freeze)
 
       attribute? :has_frozen_income_or_assets, Types::YesNoValue.optional
+      attribute? :has_no_other_assets, Types::YesNoValue.optional
     end
   end
 end

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -236,7 +236,8 @@
           ]
         }
       ],
-      "has_frozen_income_or_assets": null
+      "has_frozen_income_or_assets": null,
+      "has_no_other_assets": "yes"
     }
   },
   "supporting_evidence": [


### PR DESCRIPTION
## Description of change
Add **capitals.has_no_other_assets** to `capital_details`

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-506

## Additional notes
