### PR TITLE
Update capital details schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.58)
+    laa-criminal-legal-aid-schemas (1.0.59)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/capital_details.rb
+++ b/lib/laa_crime_schemas/structs/capital_details.rb
@@ -3,7 +3,7 @@
 module LaaCrimeSchemas
   module Structs
     class CapitalDetails < Base
-      attribute? :has_premium_bonds, Types::YesNoValue
+      attribute? :has_premium_bonds, Types::YesNoValue.optional
       attribute? :premium_bonds_total_value, Types::PenceSterling.optional
       attribute? :premium_bonds_holder_number, Types::String.optional
 

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.58'
+  VERSION = '1.0.59'
 end

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -389,12 +389,13 @@
     "capital_details":{
       "type":"object",
       "properties":{
-      	"has_premium_bonds":{"type":"string", "enum": ["yes", "no"]},
+        "has_premium_bonds": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "premium_bonds_total_value":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "premium_bonds_holder_number":{"anyOf":[{ "type":"null" }, { "type":"string" }]},
         "will_benefit_from_trust_fund":{"type":"string", "enum": ["yes", "no"]},
         "trust_fund_amount_held":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "trust_fund_yearly_dividend":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
+        "has_frozen_income_or_assets": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "savings": {
           "type": "array",
           "items": { "$ref": "#/definitions/saving" }

--- a/spec/laa_crime_schemas/structs/capital_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/capital_details_spec.rb
@@ -80,9 +80,7 @@ RSpec.describe LaaCrimeSchemas::Structs::CapitalDetails do
       context 'when nil' do
         let(:attributes) { super().merge(key => nil) }
 
-        it 'raises an error' do
-          expect { subject }.to raise_error(Dry::Struct::Error, /#{key}/)
-        end
+        it { is_expected.to be nil }
       end
 
       context 'when not a yes/no' do


### PR DESCRIPTION
## Description of change
As it is possible for applications to not go through the full capital means assessment (in the case of applications that are not either way, indictable, already in crown court cases), the premium bonds question may not be asked and can therefore be null 

The schema is updated to support this

The `has_frozen_income_assets` attribute was also added to the means json schema as it was missing

## Link to relevant ticket

## Additional notes
