### PR TITLE
Replace metadata on MAAT schema

### DIFF
--- a/schemas/1.0/maat/means.json
+++ b/schemas/1.0/maat/means.json
@@ -40,6 +40,22 @@
                   "annual"
                 ]
               },
+              "metadata":{
+                "type":"object",
+                "properties":{
+                  "details":{
+                    "anyOf": [
+                      {
+                        "type":"null"
+                      },
+                      {
+                        "type":"string"
+                      }
+                    ]
+                  }
+                },
+                "required": []
+              },
               "details":{
                 "type":"string"
               }
@@ -80,6 +96,22 @@
                   "month",
                   "annual"
                 ]
+              },
+              "metadata":{
+                "type":"object",
+                "properties":{
+                  "details":{
+                    "anyOf": [
+                      {
+                        "type":"null"
+                      },
+                      {
+                        "type":"string"
+                      }
+                    ]
+                  }
+                },
+                "required": []
               },
               "details":{
                 "type":"string"
@@ -303,6 +335,18 @@
                   "annual"
                 ]
               }
+            },
+            "metadata":{
+              "type":"object",
+              "properties":{
+                "details":{ "anyOf": [{ "type":"null" }, { "type":"string" }] },
+                "case_reference":{ "anyOf": [{ "type":"null" }, { "type":"string" }] },
+                "board_amount": { "type":"integer" },
+                "food_amount": { "type":"integer" },
+                "payee_name":{ "anyOf": [{ "type":"null" }, { "type":"string" }] },
+                "payee_relationship_to_client":{ "anyOf": [{ "type":"null" }, { "type":"string" }] }
+              },
+              "required": []
             },
             "required":[
               "payment_type",


### PR DESCRIPTION
## Description of change
Replace metadata on MAAT schema

Datastore will now transform the income_payements and income_benefits to have details extracted from metadata, but not delete metadata as originally considered
## Link to relevant ticket

## Additional notes
