### PR TITLE
[CRIMAPP-735] Add additional means attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.66)
+    laa-criminal-legal-aid-schemas (1.0.67)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/capital_details.rb
+++ b/lib/laa_crime_schemas/structs/capital_details.rb
@@ -20,7 +20,7 @@ module LaaCrimeSchemas
       attribute? :has_no_investments, Types::YesNoValue.optional
       attribute? :investments, Types::Array.of(Investment).default([].freeze)
 
-      attribute? :has_no_national_savings_certificates, Types::YesNoValue.optional
+      attribute? :has_national_savings_certificates, Types::YesNoValue.optional
       attribute? :national_savings_certificates, Types::Array.of(NationalSavingsCertificate).default([].freeze)
 
       attribute? :has_frozen_income_or_assets, Types::YesNoValue.optional

--- a/lib/laa_crime_schemas/structs/capital_details.rb
+++ b/lib/laa_crime_schemas/structs/capital_details.rb
@@ -11,9 +11,16 @@ module LaaCrimeSchemas
       attribute? :trust_fund_amount_held, Types::PenceSterling.optional
       attribute? :trust_fund_yearly_dividend, Types::PenceSterling.optional
 
+      attribute? :has_no_savings, Types::YesNoValue.optional
       attribute? :savings, Types::Array.of(Saving).default([].freeze)
+
+      attribute? :has_no_properties, Types::YesNoValue.optional
       attribute? :properties, Types::Array.of(Property).default([].freeze)
+
+      attribute? :has_no_investments, Types::YesNoValue.optional
       attribute? :investments, Types::Array.of(Investment).default([].freeze)
+
+      attribute? :has_no_national_savings_certificates, Types::YesNoValue.optional
       attribute? :national_savings_certificates, Types::Array.of(NationalSavingsCertificate).default([].freeze)
 
       attribute? :has_frozen_income_or_assets, Types::YesNoValue.optional

--- a/lib/laa_crime_schemas/structs/income_details.rb
+++ b/lib/laa_crime_schemas/structs/income_details.rb
@@ -14,6 +14,8 @@ module LaaCrimeSchemas
       attribute? :manage_without_income, Types::ManageWithoutIncomeTypes.optional
       attribute? :manage_other_details, Types::String.optional
       attribute? :client_owns_property, Types::YesNoValue.optional
+      attribute? :has_no_income_payments, Types::YesNoValue.optional
+      attribute? :has_no_income_benefits, Types::YesNoValue.optional
 
       attribute? :employment_details do
         attribute :paye, Types::Array.of(Base) do

--- a/lib/laa_crime_schemas/structs/outgoings_details.rb
+++ b/lib/laa_crime_schemas/structs/outgoings_details.rb
@@ -13,6 +13,7 @@ module LaaCrimeSchemas
       attribute? :outgoings_more_than_income, Types::YesNoValue.optional
       attribute? :how_manage, Types::String.optional
       attribute? :pays_council_tax, Types::YesNoValue.optional
+      attribute? :has_no_other_outgoings, Types::YesNoValue.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.66'
+  VERSION = '1.0.67'
 end

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -429,7 +429,7 @@
         "has_no_savings": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "has_no_properties": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "has_no_investments": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
-        "has_no_national_savings_certificates": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
+        "has_national_savings_certificates": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "savings": {
           "type": "array",
           "items": { "$ref": "#/definitions/saving" }

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -103,6 +103,28 @@
             }
           ]
         },
+        "has_no_income_payments":{
+          "anyOf":[
+            {
+              "type":"null"
+            },
+            {
+              "type":"string",
+              "enum": ["yes", "no"]
+            }
+          ]
+        },
+        "has_no_income_benefits":{
+          "anyOf":[
+            {
+              "type":"null"
+            },
+            {
+              "type":"string",
+              "enum": ["yes", "no"]
+            }
+          ]
+        },
         "has_savings":{
           "anyOf":[
             {
@@ -404,6 +426,10 @@
         "trust_fund_amount_held":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "trust_fund_yearly_dividend":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "has_frozen_income_or_assets": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
+        "has_no_savings": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
+        "has_no_properties": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
+        "has_no_investments": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
+        "has_no_national_savings_certificates": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "savings": {
           "type": "array",
           "items": { "$ref": "#/definitions/saving" }
@@ -526,6 +552,17 @@
             },
             {
               "type":"string"
+            }
+          ]
+        },
+        "has_no_other_outgoings":{
+          "anyOf":[
+            {
+              "type":"null"
+            },
+            {
+              "type":"string",
+              "enum": ["yes", "no"]
             }
           ]
         }

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -9,6 +9,8 @@
     "has_frozen_income_or_assets": "no",
     "client_owns_property": "no",
     "has_savings": "yes",
+    "has_no_income_payments": null,
+    "has_no_income_benefits": null,
     "income_benefits": [
       {
         "payment_type": "child",
@@ -60,6 +62,7 @@
     "outgoings_more_than_income": "yes",
     "how_manage": "A description of how they manage",
     "pays_council_tax": "no",
+    "has_no_other_outgoings": null,
     "outgoings": [
       {
         "payment_type": "childcare",
@@ -93,6 +96,10 @@
     "will_benefit_from_trust_fund": "yes",
     "trust_fund_amount_held": 100000,
     "trust_fund_yearly_dividend": 200000,
+    "has_no_savings": null,
+    "has_no_properties": null,
+    "has_no_investments": null,
+    "has_no_national_savings_certificates": null,
     "savings": [
       {
         "saving_type": "bank",

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -99,7 +99,7 @@
     "has_no_savings": null,
     "has_no_properties": null,
     "has_no_investments": null,
-    "has_no_national_savings_certificates": null,
+    "has_national_savings_certificates": null,
     "savings": [
       {
         "saving_type": "bank",


### PR DESCRIPTION
## Description of change
Adds attributes to means details that enable `no` answers to be persisted in apply and absent records to be displayed in apply and review 

## Link to relevant ticket

[CRIMAPP-701](https://dsdmoj.atlassian.net/browse/CRIMAPP-701)
[CRIMAPP-702](https://dsdmoj.atlassian.net/browse/CRIMAPP-702)
[CRIMAPP-735](https://dsdmoj.atlassian.net/browse/CRIMAPP-735)

## Additional notes


[CRIMAPP-701]: https://dsdmoj.atlassian.net/browse/CRIMAPP-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-702]: https://dsdmoj.atlassian.net/browse/CRIMAPP-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-735]: https://dsdmoj.atlassian.net/browse/CRIMAPP-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ