### PR TITLE
[CRIMAPP-776] Rename residence type relationship attribute

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.0.74)
+    laa-criminal-legal-aid-schemas (1.0.75)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/applicant.rb
+++ b/lib/laa_crime_schemas/structs/applicant.rb
@@ -12,7 +12,7 @@ module LaaCrimeSchemas
       attribute? :correspondence_address_type, Types::CorrespondenceAddressType.optional
       attribute? :telephone_number, Types::String.optional
       attribute? :residence_type, Types::String.optional
-      attribute? :relationship_to_someone_else, Types::String.optional
+      attribute? :relationship_to_owner_of_usual_home_address, Types::String.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.0.74'
+  VERSION = '1.0.75'
 end

--- a/schemas/1.0/general/applicant.json
+++ b/schemas/1.0/general/applicant.json
@@ -15,7 +15,7 @@
     "home_address": { "$ref": "#/definitions/address" },
     "correspondence_address": { "$ref": "#/definitions/address" },
     "residence_type": {"type": ["string", "null"], "enum": ["rented", "temporary", "parents", "esa", "applicant_owned", "partner_owned", "joint_owned", "someone_else", "none", null] },
-    "relationship_to_someone_else": { "type": ["string", "null"] }
+    "relationship_to_owner_of_usual_home_address": { "type": ["string", "null"] }
   },
   "required": [
     "date_of_birth", "nino", "telephone_number", "correspondence_address_type",

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -38,7 +38,7 @@
       },
       "correspondence_address": null,
       "residence_type": null,
-      "relationship_to_someone_else": null
+      "relationship_to_owner_of_usual_home_address": null
     }
   },
   "case_details": {

--- a/spec/fixtures/application/1.0/application_returned.json
+++ b/spec/fixtures/application/1.0/application_returned.json
@@ -32,7 +32,7 @@
       "home_address": null,
       "correspondence_address": null,
       "residence_type": null,
-      "relationship_to_someone_else": null
+      "relationship_to_owner_of_usual_home_address": null
     }
   },
   "case_details": {


### PR DESCRIPTION
## Description of change
Renames `relationship_to_someone_else` to `relationship_to_owner_of_usual_home_address` following code review

## Link to relevant ticket
[CRIMAPP-776](https://dsdmoj.atlassian.net/browse/CRIMAPP-776)

## Additional notes


[CRIMAPP-776]: https://dsdmoj.atlassian.net/browse/CRIMAPP-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ