### PR TITLE
CRIMAPP-846 Structs support 'in_progress' applications.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.1.1)
+    laa-criminal-legal-aid-schemas (1.1.2)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/base_application.rb
+++ b/lib/laa_crime_schemas/structs/base_application.rb
@@ -15,7 +15,7 @@ module LaaCrimeSchemas
       attribute :status, Types::ApplicationStatus
 
       attribute :created_at, Types::JSON::DateTime
-      attribute :submitted_at, Types::JSON::DateTime
+      attribute :submitted_at, Types::JSON::DateTime.optional
       attribute? :date_stamp, Types::JSON::DateTime.optional
       attribute? :returned_at, Types::JSON::DateTime.optional
       attribute? :reviewed_at, Types::JSON::DateTime.optional

--- a/lib/laa_crime_schemas/structs/case_details.rb
+++ b/lib/laa_crime_schemas/structs/case_details.rb
@@ -3,13 +3,13 @@
 module LaaCrimeSchemas
   module Structs
     class CaseDetails < Base
-      attribute :urn, Types::String.optional
-      attribute :case_type, Types::CaseType.optional
+      attribute? :urn, Types::String.optional
+      attribute? :case_type, Types::CaseType.optional
 
       # Injected by the datastore, not part of the stored application JSON
-      attribute :offence_class, Types::OffenceClass.optional
+      attribute? :offence_class, Types::OffenceClass.optional
 
-      attribute :appeal_lodged_date, Types::JSON::Date.optional
+      attribute? :appeal_lodged_date, Types::JSON::Date.optional
       attribute? :appeal_original_app_submitted, Types::YesNoValue.optional
       attribute? :appeal_financial_circumstances_changed, Types::YesNoValue.optional
       attribute? :appeal_with_changes_details, Types::String.optional
@@ -30,8 +30,8 @@ module LaaCrimeSchemas
       attribute :offences, Types::Array.of(Offence).constrained(min_size: 1)
       attribute :codefendants, Types::Array.of(Codefendant).default([].freeze)
 
-      attribute :hearing_court_name, Types::String
-      attribute :hearing_date, Types::JSON::Date
+      attribute? :hearing_court_name, Types::String.optional
+      attribute? :hearing_date, Types::JSON::Date.optional
 
       attribute? :is_first_court_hearing, Types::FirstHearingAnswerValues.optional
       attribute? :first_court_hearing_name, Types::String.optional

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -6,7 +6,7 @@ module LaaCrimeSchemas
       attribute? :ioj_passport, Types::Array.of(Types::IojPassportType).default([].freeze)
       attribute? :means_passport, Types::Array.of(Types::MeansPassportType).default([].freeze)
 
-      attribute :provider_details, ProviderDetails
+      attribute? :provider_details, ProviderDetails
 
       attribute :client_details, Base do
         attribute :applicant, Applicant

--- a/lib/laa_crime_schemas/structs/provider_details.rb
+++ b/lib/laa_crime_schemas/structs/provider_details.rb
@@ -3,11 +3,11 @@
 module LaaCrimeSchemas
   module Structs
     class ProviderDetails < Base
-      attribute :office_code, Types::String
-      attribute :provider_email, Types::String
-      attribute :legal_rep_first_name, Types::String
-      attribute :legal_rep_last_name, Types::String
-      attribute :legal_rep_telephone, Types::String
+      attribute :office_code, Types::String.optional
+      attribute :provider_email, Types::String.optional
+      attribute :legal_rep_first_name, Types::String.optional
+      attribute :legal_rep_last_name, Types::String.optional
+      attribute :legal_rep_telephone, Types::String.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -26,6 +26,7 @@ module LaaCrimeSchemas
       submitted
       returned
       superseded
+      in_progress
     ].freeze
     ApplicationStatus = String.enum(*APPLICATION_STATUSES)
 

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end

--- a/spec/laa_crime_schemas/structs/provider_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/provider_details_spec.rb
@@ -15,13 +15,5 @@ RSpec.describe LaaCrimeSchemas::Structs::ProviderDetails do
         expect(subject.legal_rep_telephone).to eq('123456789')
       end
     end
-
-    context 'for an invalid provider details object' do
-      let(:attributes) { super().merge('provider_email' => nil) }
-
-      it 'raises an error' do
-        expect { subject }.to raise_error(Dry::Struct::Error, /provider_email/)
-      end
-    end
   end
 end


### PR DESCRIPTION
## Description of change

On Apply providers now review a draft JSON application before they submit to the datastore. This change updates the Structs so they can be used to show an in progress application. It purposefully does not update the json-schema, which still require a submissable application.

## Link to relevant ticket

[CRIMAPP-846](https://dsdmoj.atlassian.net/browse/CRIMAPP-846)

## Additional notes


[CRIMAPP-846]: https://dsdmoj.atlassian.net/browse/CRIMAPP-846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ