### PR TITLE
CRIMAPP-945 store applicant and partner wages question on savings sep…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.1.6)
+    laa-criminal-legal-aid-schemas (1.1.7)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/saving.rb
+++ b/lib/laa_crime_schemas/structs/saving.rb
@@ -10,6 +10,7 @@ module LaaCrimeSchemas
       attribute :account_number, Types::String
       attribute :is_overdrawn, Types::YesNoValue
       attribute :are_wages_paid_into_account, Types::YesNoValue
+      attribute? :are_partners_wages_paid_into_account, Types::YesNoValue.optional
       attribute :ownership_type, Types::OwnershipType
     end
   end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.1.6'
+  VERSION = '1.1.7'
 end

--- a/schemas/1.0/general/saving.json
+++ b/schemas/1.0/general/saving.json
@@ -12,6 +12,7 @@
     "account_number": { "type": "string" },
     "is_overdrawn": { "type": "string", "enum": ["yes", "no"] },
     "are_wages_paid_into_account": { "type": "string", "enum": ["yes", "no"] },
+    "are_partners_wages_paid_into_account": { "anyOf": [{ "type": "string", "enum": ["yes", "no"] }, { "type":"null" }] },
     "ownership_type": { "type": ["string"], "enum": ["applicant", "applicant_and_partner", "partner"] }
   },
   "required": ["saving_type", "provider_name", "account_balance", "sort_code", "account_number", "is_overdrawn", "are_wages_paid_into_account", "ownership_type"]

--- a/schemas/1.0/maat/means.json
+++ b/schemas/1.0/maat/means.json
@@ -479,7 +479,13 @@
                   "yes",
                   "no"
                 ]
-              }
+              },
+	      "are_partners_wages_paid_into_account": {
+                "anyOf": [
+                  { "type": "string", "enum": ["yes", "no"] },
+		  { "type":"null" }
+		]
+	      }
             },
             "required":[
               "saving_type",

--- a/spec/laa_crime_schemas/structs/saving_spec.rb
+++ b/spec/laa_crime_schemas/structs/saving_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe LaaCrimeSchemas::Structs::Saving do
         expect(subject.account_balance).to eq(200)
         expect(subject.is_overdrawn).to eq('yes')
         expect(subject.are_wages_paid_into_account).to eq('yes')
+        expect(subject.are_partners_wages_paid_into_account).to be_nil
         expect(subject.ownership_type).to eq('applicant')
       end
     end


### PR DESCRIPTION
## Description of change

Savings form has been updated to ask the question about the partner and clients wages separately. This change updates Savings to optionally accept details about the partners wages.

This new field is not required (to support older applications)
This new field can be null (only required when partner is included in the means assessment).


## Link to relevant ticket

[CRIMAPP-945](https://dsdmoj.atlassian.net/browse/CRIMAPP-945)

## Additional notes


[CRIMAPP-945]: https://dsdmoj.atlassian.net/browse/CRIMAPP-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ