### PR TITLE
NO TICKET: Remove self_assessment_tax_bill attribute from outgoings payment types

### DIFF
--- a/schemas/1.0/maat/means.json
+++ b/schemas/1.0/maat/means.json
@@ -344,8 +344,7 @@
                   "council_tax",
                   "childcare",
                   "maintenance",
-                  "legal_aid_contribution",
-                  "self_assessment_tax_bill"
+                  "legal_aid_contribution"
                 ]
               },
               "amount":{

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -574,8 +574,7 @@
                   "council_tax",
                   "childcare",
                   "maintenance",
-                  "legal_aid_contribution",
-                  "self_assessment_tax_bill"
+                  "legal_aid_contribution"
                 ]
               },
               "amount":{

--- a/spec/laa_crime_schemas/types/types_spec.rb
+++ b/spec/laa_crime_schemas/types/types_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe LaaCrimeSchemas::Types do
         end
 
         context 'for EmploymentOutgoingsPaymentType' do
-          it 'returns all income payment types' do
+          it 'returns all employment outgoings payment types' do
             expect(LaaCrimeSchemas::Types::EmploymentOutgoingsPaymentType.values).to match_array(%w[
               self_assessment_tax_bill
           ])
@@ -82,7 +82,7 @@ RSpec.describe LaaCrimeSchemas::Types do
         end
 
         context 'for OutgoingsType' do
-          it 'returns all income payment types' do
+          it 'returns all outgoings payment types' do
             expect(LaaCrimeSchemas::Types::OutgoingsType.values).to match_array(%w[
               rent
               mortgage


### PR DESCRIPTION
## Description of change
Remove `self_assessment_tax_bill` from outgoings payments.
We decided to create `self_assessment_tax_bill` attributes in income table. Here is the PR: [PR](https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/925)

## Link to relevant ticket

## Additional notes
