### PR TITLE
Amend involvement in case type error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.1.18)
+    laa-criminal-legal-aid-schemas (1.1.19)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.1.18'
+  VERSION = '1.1.19'
 end

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -55,7 +55,7 @@
             "nino": { "type": ["string", "null"] },
             "benefit_type": {"type": ["string", "null"], "enum": ["universal_credit", "guarantee_pension", "jsa", "esa", "income_support", "none", null] },
             "last_jsa_appointment_date": { "type": ["string", "null"], "format": "date" },
-            "involvement_in_case": {"type": ["string", "null"], "enum": ["victim", "prosecution_witness", "codefendant", "no_involvement", null] },
+            "involvement_in_case": {"type": ["string", "null"], "enum": ["victim", "prosecution_witness", "codefendant", "none", null] },
             "conflict_of_interest": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]}
           },
           "required": ["first_name", "last_name", "date_of_birth"]


### PR DESCRIPTION
## Description of change
Fixes issue reported with injecting partner details for maat. The `involvement_in_case` attribute incorrectly includes the value `no_involvement` rather than `none`

## Link to relevant ticket

## Additional notes
