### PR TITLE
Update schema to remove employment as income payment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.1.19)
+    laa-criminal-legal-aid-schemas (1.1.20)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.1.19'
+  VERSION = '1.1.20'
 end

--- a/schemas/1.0/maat/means.json
+++ b/schemas/1.0/maat/means.json
@@ -25,7 +25,6 @@
                   "rent",
                   "financial_support_with_access",
                   "from_friends_relatives",
-                  "employment",
                   "work_benefits",
                   "other"
                 ]

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -147,6 +147,18 @@
           "amount": 150,
           "frequency": "month",
           "ownership_type": "partner"
+        },
+        {
+          "payment_type": "work_benefits",
+          "amount": 250,
+          "frequency": "annual",
+          "ownership_type": "applicant"
+        },
+        {
+          "payment_type": "work_benefits",
+          "amount": 250,
+          "frequency": "annual",
+          "ownership_type": "partner"
         }
       ],
       "income_benefits": [


### PR DESCRIPTION
## Description of change
- We are saving `income < 12,475`, in **income_payments** table where payment_type == 'employment'
- We are saving `income > 12,475`, in **employments** table

MATT schema doesn't care about above separation so we have to send `income < 12,475` or `income  >  12,475`  as an **employment_income_payments**

## Link to relevant ticket

## Additional notes


<img width="1718" alt="Screenshot 2024-06-24 at 11 35 09" src="https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/assets/195928/bb3ead46-9a8d-4295-8f0b-29fd337ff00c">
