### PR TITLE
[CRIMAPP-1069] Set default values for employment_type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.1.23)
+    laa-criminal-legal-aid-schemas (1.1.24)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/base_application.rb
+++ b/lib/laa_crime_schemas/structs/base_application.rb
@@ -12,7 +12,7 @@ module LaaCrimeSchemas
       attribute :schema_version, Types::SchemaVersion
       attribute :reference, Types::ApplicationReference
       attribute :application_type, Types::ApplicationType
-      attribute :status, Types::ApplicationStatus
+      attribute? :status, Types::ApplicationStatus
 
       attribute :created_at, Types::JSON::DateTime
       attribute :submitted_at, Types::JSON::DateTime.optional

--- a/lib/laa_crime_schemas/structs/income_details.rb
+++ b/lib/laa_crime_schemas/structs/income_details.rb
@@ -4,9 +4,8 @@ module LaaCrimeSchemas
   module Structs
     class IncomeDetails < Base
       attribute? :income_above_threshold, Types::YesNoValue.optional
-
-      attribute? :employment_type, Types::Array.of(Types::EmploymentType)
-      attribute? :partner_employment_type, Types::Array.of(Types::EmploymentType)
+      attribute? :employment_type, Types::Array.of(Types::EmploymentType).default([].freeze)
+      attribute? :partner_employment_type, Types::Array.of(Types::EmploymentType).default([].freeze)
       attribute? :ended_employment_within_three_months, Types::YesNoValue.optional
       attribute? :lost_job_in_custody, Types::YesNoValue.optional
       attribute? :date_job_lost, Types::JSON::Date.optional

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -289,6 +289,8 @@ module LaaCrimeSchemas
                                          confirmed])
 
     BusinessInvolvementType = String.enum(*%w[self_employed partnership director_or_shareholder])
+
+    EXTRADITION_COURT_NAMES = ["Westminster Magistrates' Court"].freeze
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.1.23'
+  VERSION = '1.1.24'
 end

--- a/spec/laa_crime_schemas/structs/income_details_spec.rb
+++ b/spec/laa_crime_schemas/structs/income_details_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe LaaCrimeSchemas::Structs::IncomeDetails do
+  describe 'schema version 1.0' do
+    subject(:struct) { described_class.new(attributes) }
+
+    let(:valid_fixture) { 'application/1.0/means.json' }
+
+    let(:attributes) do
+      JSON.parse(file_fixture(valid_fixture).read)['income_details']
+    end
+
+    describe '#employment_type' do
+      subject(:employment_type) { struct.employment_type }
+
+      context 'when not given' do
+        let(:attributes) { {} }
+
+        it { is_expected.to eq [] }
+      end
+      
+      context 'when given as nil' do
+        let(:attributes) { { employment_type: nil} }
+
+        it 'raises Dry::Struct::Error' do
+          expect { struct } .to raise_error Dry::Struct::Error
+        end
+      end
+
+      context 'when given' do
+        it { is_expected.to eq ['employed'] }
+      end
+    end
+
+    describe '#partner_employment_type' do
+      subject(:partner_employment_type) { struct.partner_employment_type }
+
+      context 'when not given' do
+        let(:attributes) { {} }
+
+        it { is_expected.to eq [] }
+      end
+      
+      context 'when given as nil' do
+        let(:attributes) { { partner_employment_type: nil} }
+
+        it 'raises Dry::Struct::Error' do
+          expect { struct } .to raise_error Dry::Struct::Error
+        end
+      end
+
+      context 'when given' do
+        let(:attributes) { { partner_employment_type: ['self_employed', 'employed'] } }
+        it { is_expected.to eq ['self_employed', 'employed'] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Set default values for parter and applicant employment types
No longer require status for CrimeApplication struct

## Link to relevant ticket
[CRIMAPP-1069](https://dsdmoj.atlassian.net/browse/CRIMAPP-1069)

## Additional notes


[CRIMAPP-1069]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ