### PR TITLE
CRIMAPP-1230 Structs support draft applications

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.1.33)
+    laa-criminal-legal-aid-schemas (1.2.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/investment.rb
+++ b/lib/laa_crime_schemas/structs/investment.rb
@@ -4,8 +4,8 @@ module LaaCrimeSchemas
   module Structs
     class Investment < Base
       attribute :investment_type, Types::InvestmentType
-      attribute :description, Types::String
-      attribute :value, Types::PenceSterling
+      attribute? :description, Types::String.optional
+      attribute? :value, Types::PenceSterling.optional
       attribute :ownership_type, Types::OwnershipType
     end
   end

--- a/lib/laa_crime_schemas/structs/national_savings_certificate.rb
+++ b/lib/laa_crime_schemas/structs/national_savings_certificate.rb
@@ -3,9 +3,9 @@
 module LaaCrimeSchemas
   module Structs
     class NationalSavingsCertificate < Base
-      attribute :holder_number, Types::String
-      attribute :certificate_number, Types::String
-      attribute :value, Types::PenceSterling
+      attribute? :holder_number, Types::String.optional
+      attribute? :certificate_number, Types::String.optional
+      attribute? :value, Types::PenceSterling.optional
       attribute :ownership_type, Types::OwnershipType
     end
   end

--- a/lib/laa_crime_schemas/structs/partner.rb
+++ b/lib/laa_crime_schemas/structs/partner.rb
@@ -3,12 +3,6 @@
 module LaaCrimeSchemas
   module Structs
     class Partner < Person
-      # TODO: Although Partner is an optional Struct, and not required in
-      # json-schema, dry-types keeps requiring first_name/last_name as defined in
-      # the Partner Struct type
-      attribute? :first_name, Types::String
-      attribute? :last_name, Types::String
-
       attribute? :date_of_birth, Types::JSON::Date.optional
       attribute? :benefit_type, Types::BenefitType.optional
       attribute? :last_jsa_appointment_date, Types::JSON::Date.optional

--- a/lib/laa_crime_schemas/structs/person.rb
+++ b/lib/laa_crime_schemas/structs/person.rb
@@ -5,13 +5,8 @@ module LaaCrimeSchemas
     class Person < Base
       include Traits::FullName
 
-      attribute :first_name, Types::String
-      attribute :last_name, Types::String
-
-      # This struct is used via composition in other structs
-      # like `codefendant`, `applicant` and potentially in the
-      # future `partner`, and not all of them ask `other_names`,
-      # thus the attribute presence is optional (and value too).
+      attribute? :first_name, Types::String.optional
+      attribute? :last_name, Types::String.optional
       attribute? :other_names, Types::String.optional
     end
   end

--- a/lib/laa_crime_schemas/structs/saving.rb
+++ b/lib/laa_crime_schemas/structs/saving.rb
@@ -5,7 +5,7 @@ module LaaCrimeSchemas
     class Saving < Base
       attribute :saving_type, Types::SavingType
       attribute? :provider_name, Types::String.optional
-      attribute :account_balance, Types::PenceSterling
+      attribute? :account_balance, Types::PenceSterling.optional
       attribute? :sort_code, Types::String.optional
       attribute? :account_number, Types::String.optional
       attribute? :is_overdrawn, Types::YesNoValue.optional

--- a/lib/laa_crime_schemas/structs/saving.rb
+++ b/lib/laa_crime_schemas/structs/saving.rb
@@ -4,14 +4,14 @@ module LaaCrimeSchemas
   module Structs
     class Saving < Base
       attribute :saving_type, Types::SavingType
-      attribute :provider_name, Types::String
+      attribute? :provider_name, Types::String.optional
       attribute :account_balance, Types::PenceSterling
-      attribute :sort_code, Types::String
-      attribute :account_number, Types::String
-      attribute :is_overdrawn, Types::YesNoValue
-      attribute :are_wages_paid_into_account, Types::YesNoValue
+      attribute? :sort_code, Types::String.optional
+      attribute? :account_number, Types::String.optional
+      attribute? :is_overdrawn, Types::YesNoValue.optional
+      attribute? :are_wages_paid_into_account, Types::YesNoValue.optional
       attribute? :are_partners_wages_paid_into_account, Types::YesNoValue.optional
-      attribute :ownership_type, Types::OwnershipType
+      attribute? :ownership_type, Types::OwnershipType.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.1.33'
+  VERSION = '1.2.0'
 end

--- a/spec/laa_crime_schemas/structs/codefendant_spec.rb
+++ b/spec/laa_crime_schemas/structs/codefendant_spec.rb
@@ -21,13 +21,5 @@ RSpec.describe LaaCrimeSchemas::Structs::Codefendant do
         expect(subject.full_name).to eq('John Doe')
       end
     end
-
-    context 'for an invalid codefendant object' do
-      let(:attributes) { { 'foo' => 'bar' } }
-
-      it 'raises an error' do
-        expect { subject }.to raise_error(Dry::Struct::Error, /first_name/)
-      end
-    end
   end
 end

--- a/spec/laa_crime_schemas/structs/crime_application_spec.rb
+++ b/spec/laa_crime_schemas/structs/crime_application_spec.rb
@@ -23,18 +23,6 @@ RSpec.describe LaaCrimeSchemas::Structs::CrimeApplication do
       end
     end
 
-    context 'for an invalid crime application object' do
-      let(:attributes) do
-        json = JSON.parse(file_fixture(valid_fixture).read)
-        json['client_details']['applicant'] = nil
-        json
-      end
-
-      it 'raises an error' do
-        expect { subject }.to raise_error(Dry::Struct::Error, /first_name/)
-      end
-    end
-
     context 'for an invalid `correspondence_address_type` attribute' do
       let(:attributes) do
         json = JSON.parse(file_fixture(valid_fixture).read)

--- a/spec/laa_crime_schemas/structs/pruned_application_spec.rb
+++ b/spec/laa_crime_schemas/structs/pruned_application_spec.rb
@@ -20,17 +20,5 @@ RSpec.describe LaaCrimeSchemas::Structs::PrunedApplication do
         expect(validator).to be_valid, validator.fully_validate
       end
     end
-
-    context 'for an invalid pruned crime application object' do
-      let(:attributes) do
-        json = JSON.parse(file_fixture(fixture).read)
-        json['client_details']['applicant'] = nil
-        json
-      end
-
-      it 'raises an error' do
-        expect { subject }.to raise_error(Dry::Struct::Error, /first_name/)
-      end
-    end
   end
 end


### PR DESCRIPTION
## Description of change

v 1.2.0
Structs support draft applications. 

## Link to relevant ticket
[CRIMAPP-1230](https://dsdmoj.atlassian.net/browse/CRIMAPP-1230)

## Additional notes

This change is to allow them to be used an Apply for draft applications (see: https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/1085 )

[CRIMAPP-1230]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ