### PR TITLE
CRIMAPP-1119 Update enums for income payments and benefits

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.2.3)
+    laa-criminal-legal-aid-schemas (1.2.4)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.2.3'
+  VERSION = '1.2.4'
 end

--- a/schemas/1.0/maat/means.json
+++ b/schemas/1.0/maat/means.json
@@ -20,11 +20,6 @@
                   "state_pension",
                   "maintenance",
                   "interest_investment",
-                  "student_loan_grant",
-                  "board_from_family",
-                  "rent",
-                  "financial_support_with_access",
-                  "from_friends_relatives",
                   "work_benefits",
                   "other"
                 ]
@@ -88,7 +83,6 @@
                   "working_or_child_tax_credit",
                   "incapacity",
                   "industrial_injuries_disablement",
-                  "jsa",
                   "other"
                 ]
               },

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -100,53 +100,11 @@
           "ownership_type": "applicant"
         },
         {
-          "payment_type": "student_loan_grant",
-          "amount": 55,
-          "frequency": "month",
-          "ownership_type": "applicant"
-        },
-        {
-          "payment_type": "board_from_family",
-          "amount": 1000,
-          "frequency": "annual",
-          "ownership_type": "applicant"
-        },
-        {
-          "payment_type": "from_friends_relatives",
-          "amount": 50,
-          "frequency": "week",
-          "ownership_type": "applicant"
-        },
-        {
-          "payment_type": "rent",
-          "amount": 310,
-          "frequency": "month",
-          "ownership_type": "applicant"
-        },
-        {
-          "payment_type": "financial_support_with_access",
-          "amount": 80,
-          "frequency": "month",
-          "ownership_type": "applicant"
-        },
-        {
-          "payment_type": "from_friends_relatives",
-          "amount": 390,
-          "frequency": "month",
-          "ownership_type": "applicant"
-        },
-        {
           "payment_type": "other",
           "amount": 250,
           "frequency": "month",
           "details": "Details of the other payment",
           "ownership_type": "applicant"
-        },
-        {
-          "payment_type": "rent",
-          "amount": 150,
-          "frequency": "month",
-          "ownership_type": "partner"
         },
         {
           "payment_type": "work_benefits",
@@ -184,12 +142,6 @@
           "payment_type": "industrial_injuries_disablement",
           "amount": 400,
           "frequency": "month",
-          "ownership_type": "applicant"
-        },
-        {
-          "payment_type": "jsa",
-          "amount": 400,
-          "frequency": "annual",
           "ownership_type": "applicant"
         },
         {


### PR DESCRIPTION
## Description of change

MAAT doesn't require the following `payment_type` enums for `income_payments` and `income_benefits`

### income_payments
- student_loan_grant
- board_from_family
- rent
- financial_support_with_access
- from_friends_relatives

### income_benefits
- jsa

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1119

## Additional notes
