### PR TITLE
CRIMAPP-1318  Dividends from a trust fund - considered as ‘income’ and needs to be added to the total value of 'Other Income' in MAAT

### DIFF
--- a/schemas/1.0/maat/means.json
+++ b/schemas/1.0/maat/means.json
@@ -228,7 +228,7 @@
             ]
           }
         },
-        "capital_attributes": {
+        "dividends": {
           "type":"object",
           "properties":{
             "trust_fund_yearly_dividend":{

--- a/schemas/1.0/maat/means.json
+++ b/schemas/1.0/maat/means.json
@@ -227,6 +227,31 @@
               "age"
             ]
           }
+        },
+        "capital_attributes": {
+          "type":"object",
+          "properties":{
+            "trust_fund_yearly_dividend":{
+              "anyOf":[
+                {
+                  "type":"null"
+                },
+                {
+                  "type":"integer"
+                }
+              ]
+            },
+            "partner_trust_fund_yearly_dividend":{
+              "anyOf":[
+                {
+                  "type":"null"
+                },
+                {
+                  "type":"integer"
+                }
+              ]
+            }
+          }
         }
       },
       "required":[]
@@ -317,6 +342,16 @@
             }
           ]
         },
+        "trust_fund_yearly_dividend":{
+          "anyOf":[
+            {
+              "type":"null"
+            },
+            {
+              "type":"integer"
+            }
+          ]
+        },
         "partner_premium_bonds_total_value":{
           "anyOf":[
             {
@@ -328,6 +363,16 @@
           ]
         },
         "partner_trust_fund_amount_held":{
+          "anyOf":[
+            {
+              "type":"null"
+            },
+            {
+              "type":"integer"
+            }
+          ]
+        },
+        "partner_trust_fund_yearly_dividend":{
           "anyOf":[
             {
               "type":"null"


### PR DESCRIPTION
## Description of change
Include applicant and partner dividends from a trust fund to total value of 'Other Income' in MAAT
 OTHER_INCOME_PAYMENT_TYPES(including dividend)
- student_loan_grant
- board_from_family
- rent
- financial_support_with_access
- from_friends_relatives
- other
- trust_fund_dividend

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1318

## Additional notes

- Trust fund dividend attributes (`trust_fund_yearly_dividend`, `partner_trust_fund_yearly_dividend`) belongs to `capital_details` object. To add trust fund dividends to 'other_incomes' we need to pass these attributes to `income_details` object. 
- Created `dividends` object by including trust fund dividend attributes and merged it with `income_details` object
Here is the reference PR: https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/317
