### PR TITLE
CRIMAPP-1288 Appeal to crown court applications not injecting to MAAT

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.2.9)
+    laa-criminal-legal-aid-schemas (1.3.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.2.9'
+  VERSION = '1.3.0'
 end

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -37,7 +37,7 @@
             "benefit_type": {"type": ["string", "null"], "enum": ["universal_credit", "guarantee_pension", "jsa", "esa", "income_support", "none", null] },
             "last_jsa_appointment_date": { "type": ["string", "null"], "format": "date" },
             "telephone_number": { "type": ["string", "null"] },
-            "correspondence_address_type": { "type": "string", "enum": ["other_address", "home_address", "providers_office_address"] },
+            "correspondence_address_type": { "anyOf": [ {"type": "null"}, { "type": "string", "enum": ["other_address", "home_address", "providers_office_address"] } ] },
             "residence_type": {"type": ["string", "null"], "enum": ["rented", "temporary", "parents", "applicant_owned", "partner_owned", "joint_owned", "someone_else", "none", null] },
             "home_address": { "$ref": "#/definitions/address" },
             "correspondence_address": { "$ref": "#/definitions/address" },

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -69,6 +69,7 @@
         "urn": { "type": ["string", "null"] },
         "case_type": { "type": "string", "enum": ["summary_only", "either_way", "indictable", "already_in_crown_court", "committal", "appeal_to_crown_court", "appeal_to_crown_court_with_changes"] },
         "appeal_maat_id": { "type": ["string", "null"] },
+        "appeal_usn": { "type": ["string", "null"] },
         "appeal_lodged_date": { "type": ["string", "null"], "format": "date" },
         "appeal_with_changes_details": { "type": ["string", "null"] },
         "offence_class": { "type": ["string", "null"], "enum": ["A", "K", "G", "B", "I", "J", "D", "C", "H", "F", "E", null] },

--- a/spec/fixtures/application/1.0/maat_application.json
+++ b/spec/fixtures/application/1.0/maat_application.json
@@ -55,6 +55,7 @@
     "case_type": "appeal_to_crown_court",
     "offence_class": "A",
     "appeal_maat_id": null,
+    "appeal_usn": null,
     "appeal_lodged_date": "2021-10-25",
     "appeal_with_changes_details": null,
     "hearing_court_name": "Cardiff Magistrates' Court",


### PR DESCRIPTION
## Description of change

- Validation error occurs when correspondence_address_type is not present. So we need to make it optional as   `correspondence_address_type` is not required for 'Appeal to crown court' applications
- Exposing  :appeal_usn attribute (may be required for MAAT)

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1288

## Notes for reviewer / how to test


