### PR TITLE
CRIMAPP-1288 Appeal to crown court applications not injecting to maat with missing hearing date

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.3.0)
+    laa-criminal-legal-aid-schemas (1.3.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end

--- a/schemas/1.0/maat_application.json
+++ b/schemas/1.0/maat_application.json
@@ -74,7 +74,7 @@
         "appeal_with_changes_details": { "type": ["string", "null"] },
         "offence_class": { "type": ["string", "null"], "enum": ["A", "K", "G", "B", "I", "J", "D", "C", "H", "F", "E", null] },
         "hearing_court_name": { "type": "string" },
-        "hearing_date": { "type": "string", "format": "date" }
+        "hearing_date": { "type": ["string", "null"], "format": "date" }
       },
       "required": ["case_type", "hearing_court_name", "hearing_date", "offence_class"]
     },


### PR DESCRIPTION
## Description of change
Validation error occurs when `#/case_details/hearing_date` is not present. So we need to make it optional as `hearing_date` is not required for **A change in financial circumstances** >  **Appeal to crown court** applications

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1288

## Additional notes
