### PR TITLE
[CRIMAPP-1398] Add case_id to Decision

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.4.0)
+    laa-criminal-legal-aid-schemas (1.4.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/decision.rb
+++ b/lib/laa_crime_schemas/structs/decision.rb
@@ -5,6 +5,7 @@ module LaaCrimeSchemas
     class Decision < Base
       attribute? :reference, Types::Integer.optional
       attribute? :maat_id, Types::Integer.optional
+      attribute? :case_id, Types::String.optional
       attribute? :interests_of_justice, Types::Nil | TestResult
       attribute? :means, Types::Nil | TestResult
       attribute :funding_decision, Types::FundingDecisionResult

--- a/lib/laa_crime_schemas/validator.rb
+++ b/lib/laa_crime_schemas/validator.rb
@@ -6,10 +6,11 @@ module LaaCrimeSchemas
 
     attr_reader :document, :version
 
-    def initialize(document, version: nil, schema_name: 'application')
+    def initialize(document, version: nil, schema_name: 'application', list: false)
       @document = document
       @version = version
       @schema_name = schema_name
+      @list = list
     end
 
     def schema_version
@@ -18,7 +19,7 @@ module LaaCrimeSchemas
 
     def valid?
       JSON::Validator.validate(
-        schema, document, validate_schema: true
+        schema, document, validate_schema: true, list:
       )
     rescue JSON::Schema::ReadFailed => e
       raise Errors::SchemaNotFoundError, e.message
@@ -26,7 +27,7 @@ module LaaCrimeSchemas
 
     def fully_validate
       JSON::Validator.fully_validate(
-        schema, document, validate_schema: true, errors_as_objects: true
+        schema, document, validate_schema: true, errors_as_objects: true, list:
       )
     rescue JSON::Schema::ReadFailed => e
       raise Errors::SchemaNotFoundError, e.message
@@ -34,7 +35,7 @@ module LaaCrimeSchemas
 
     private
 
-    attr_reader :schema_name
+    attr_reader :schema_name, :list
 
     def schema
       File.join(LaaCrimeSchemas.root, 'schemas', schema_version.to_s, "#{schema_name}.json")

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end

--- a/schemas/1.0/general/decision.json
+++ b/schemas/1.0/general/decision.json
@@ -1,65 +1,145 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "ministryofjustice/laa-criminal-legal-aid-schemas/main/schemas/1.0/general/decision.json",
   "title": "Decision",
   "description": "Holds attributes of a decision",
   "type": "object",
   "properties": {
     "reference": {
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
     },
     "maat_id": {
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "case_id": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "interests_of_justice": {
-      "type": "object",
-      "properties": {
-        "result": {
-          "type": "string",
-          "enum": [
-            "pass",
-            "fail"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string",
+              "enum": [
+                "pass",
+                "fail",
+                "inel",
+                "full"
+              ]
+            },
+            "details": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "assessed_by": {
+              "type": "string"
+            },
+            "assessed_on": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          "required": [
+            "result",
+            "assessed_by",
+            "assessed_on"
           ]
-        },
-        "details": {
-          "type": "string"
-        },
-        "assessed_by": {
-          "type": "string"
-        },
-        "assessed_on": {
-          "type": "string",
-          "format": "date-time"
         }
-      }
+      ]
     },
     "means": {
-      "type": "object",
-      "properties": {
-        "result": {
-          "type": "string",
-          "enum": [
-            "pass",
-            "fail"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string",
+              "enum": [
+                "pass",
+                "fail",
+                "inel",
+                "full"
+              ]
+            },
+            "details": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "assessed_by": {
+              "type": "string"
+            },
+            "assessed_on": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          "required": [
+            "result",
+            "assessed_by",
+            "assessed_on"
           ]
-        },
-        "details": {
-          "type": "string"
-        },
-        "assessed_by": {
-          "type": "string"
-        },
-        "assessed_on": {
-          "type": "string",
-          "format": "date-time"
         }
-      }
+      ]
     },
     "funding_decision": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "granted",
+        "granted_on_ioj",
+        "fail_on_ioj",
+        "failmeans",
+        "failioj"
+      ]
     },
     "comment": {
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
     }
   },
   "required": [

--- a/spec/laa_crime_schemas/structs/decision_spec.rb
+++ b/spec/laa_crime_schemas/structs/decision_spec.rb
@@ -8,13 +8,19 @@ RSpec.describe LaaCrimeSchemas::Structs::Decision do
         {
           'reference' => 1234,
           'maat_id' => nil,
+          'case_id' => "123123123",
           'interests_of_justice' => {
             'result' => 'pass',
-            'details' => 'decision details',
+            'details' => 'ioj details',
             'assessed_by' => 'Grace Nolan',
             'assessed_on' => '2024-10-01 00:00:00'
           },
-          'means' => nil,
+          'means' => {
+            'result' => 'fail',
+            'details' => 'means details',
+            'assessed_by' => 'Kory Liam',
+            'assessed_on' => '2024-11-01 00:00:00'
+          },
           'funding_decision' => 'granted',
           'comment' => 'test comment'
         }
@@ -23,11 +29,15 @@ RSpec.describe LaaCrimeSchemas::Structs::Decision do
       it 'builds a decision struct' do
         expect(subject.reference).to eq(1234)
         expect(subject.maat_id).to be_nil
+        expect(subject.case_id).to eq("123123123")
         expect(subject.interests_of_justice.result).to eq('pass')
-        expect(subject.interests_of_justice.details).to eq('decision details')
+        expect(subject.interests_of_justice.details).to eq('ioj details')
         expect(subject.interests_of_justice.assessed_by).to eq('Grace Nolan')
         expect(subject.interests_of_justice.assessed_on).to eq(Date.new(2024, 10, 1))
-        expect(subject.means).to be_nil
+        expect(subject.means.result).to eq('fail')
+        expect(subject.means.details).to eq('means details')
+        expect(subject.means.assessed_by).to eq('Kory Liam')
+        expect(subject.means.assessed_on).to eq(Date.new(2024, 11, 1))
         expect(subject.funding_decision).to eq('granted')
         expect(subject.comment).to eq('test comment')
       end

--- a/spec/laa_crime_schemas/validator_spec.rb
+++ b/spec/laa_crime_schemas/validator_spec.rb
@@ -160,4 +160,33 @@ RSpec.describe LaaCrimeSchemas::Validator do
       end
     end
   end
+
+  describe 'list of decisions' do
+    subject { described_class.new(document, version: version, schema_name: 'general/decision', list: true) }
+
+    let(:document) do
+      [
+        {
+          'interests_of_justice' => {
+            'result' => 'pass',
+            'assessed_by' => 'Kory Liam',
+            'assessed_on' => '2024-10-04'
+          }
+        },
+        {
+          'funding_decision' => 'fail_on_ioj',
+          'interests_of_justice' => {
+            'result' => 'pass',
+            'assessed_by' => 'Kory Liam'
+          }
+        }
+      ]
+    end
+
+    let(:version) { 1.0 }
+    
+    it 'validates every document' do
+      expect(subject.fully_validate.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
1. Added `case_id` to the Decision struct/schema.
2. Regenerated the `decision` schema using `JSON.pretty_generate`.
3. Added the `list` parameter to the validator to enable it to validate arrays of objects against a schema.

## Link to relevant ticket
[CRIMAPP-1398](https://dsdmoj.atlassian.net/browse/CRIMAPP-1398)

[CRIMAPP-1398]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ