### PR TITLE
[CRIMAPP-1453] LAA-APPLY-FOR-CRIMINAL-LEGAL-AID-2Y fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.4.1)
+    laa-criminal-legal-aid-schemas (1.4.2)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/amount.rb
+++ b/lib/laa_crime_schemas/structs/amount.rb
@@ -3,8 +3,8 @@
 module LaaCrimeSchemas
   module Structs
     class Amount < Base
-      attribute :amount, Types::PenceSterling
-      attribute :frequency, Types::PaymentFrequency
+      attribute :amount, Types::PenceSterling.optional
+      attribute :frequency, Types::PaymentFrequency.optional
 
       attribute? :metadata do
         attribute? :details, Types::String.optional

--- a/lib/laa_crime_schemas/structs/codefendant.rb
+++ b/lib/laa_crime_schemas/structs/codefendant.rb
@@ -3,7 +3,7 @@
 module LaaCrimeSchemas
   module Structs
     class Codefendant < Person
-      attribute :conflict_of_interest, Types::YesNoValue
+      attribute :conflict_of_interest, Types::YesNoValue.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/investment.rb
+++ b/lib/laa_crime_schemas/structs/investment.rb
@@ -6,7 +6,7 @@ module LaaCrimeSchemas
       attribute :investment_type, Types::InvestmentType
       attribute? :description, Types::String.optional
       attribute? :value, Types::PenceSterling.optional
-      attribute :ownership_type, Types::OwnershipType
+      attribute :ownership_type, Types::OwnershipType.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/national_savings_certificate.rb
+++ b/lib/laa_crime_schemas/structs/national_savings_certificate.rb
@@ -6,7 +6,7 @@ module LaaCrimeSchemas
       attribute? :holder_number, Types::String.optional
       attribute? :certificate_number, Types::String.optional
       attribute? :value, Types::PenceSterling.optional
-      attribute :ownership_type, Types::OwnershipType
+      attribute :ownership_type, Types::OwnershipType.optional
     end
   end
 end

--- a/lib/laa_crime_schemas/structs/property.rb
+++ b/lib/laa_crime_schemas/structs/property.rb
@@ -9,12 +9,12 @@ module LaaCrimeSchemas
       attribute :size_in_acres, Types::Integer.optional
       attribute :usage, Types::String.optional
       attribute :bedrooms, Types::Integer.optional
-      attribute :value, Types::PenceSterling
-      attribute :outstanding_mortgage, Types::PenceSterling
-      attribute :percentage_applicant_owned, Types::Float
+      attribute :value, Types::PenceSterling.optional
+      attribute :outstanding_mortgage, Types::PenceSterling.optional
+      attribute :percentage_applicant_owned, Types::Float.optional
       attribute :percentage_partner_owned, Types::Float.optional
       attribute :is_home_address, Types::YesNoValue.optional
-      attribute :has_other_owners, Types::YesNoValue
+      attribute :has_other_owners, Types::YesNoValue.optional
       attribute :address, Address.optional
       attribute? :property_owners, Types::Array.of(PropertyOwner).default([].freeze)
     end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end


### PR DESCRIPTION
## Description of change

Fixes a couple of sentry errors linked in the ticket.

Users are being thrown errors on the evidence upload and review page when there are incomplete employment, Investment, co-defendant, saving and national saving certificate records. This is because the application's data is used to recreate a draft version of the application based on the schema. For some attributes, nil values were not permitted and so errors were being thrown. Nil values are now permitted

## Link to relevant ticket
[dsdmoj.atlassian.net/browse/CRIMAPP-1453](https://dsdmoj.atlassian.net/browse/CRIMAPP-1453)

## Additional notes
