### PR TITLE
CRIMAPP 907 revise decision data model

### DIFF
--- a/lib/laa_crime_schemas/structs/decision.rb
+++ b/lib/laa_crime_schemas/structs/decision.rb
@@ -8,7 +8,8 @@ module LaaCrimeSchemas
       attribute? :case_id, Types::String.optional
       attribute? :interests_of_justice, Types::Nil | TestResult
       attribute? :means, Types::Nil | TestResult
-      attribute :funding_decision, Types::FundingDecision
+      attribute? :funding_decision, Types::FundingDecision.optional
+      attribute? :overall_result, Types::String.optional
       attribute? :comment, Types::String.optional
     end
   end

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -293,10 +293,10 @@ module LaaCrimeSchemas
 
     EXTRADITION_COURT_NAMES = ["Westminster Magistrates' Court"].freeze
 
-    TestResult = String.enum('pass', 'fail', 'contribution_required')
+    TestResult = String.enum('passed', 'failed', 'passed_with_contribution')
     MeansResult = TestResult
-    InterestsOfJusticeResult = String.enum(TestResult['pass'], TestResult['fail'])
-    FundingDecision = String.enum(*%w[grant refuse])
+    InterestsOfJusticeResult = String.enum(TestResult['passed'], TestResult['failed'])
+    FundingDecision = String.enum(*%w[granted refused])
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/schemas/1.0/general/decision.json
+++ b/schemas/1.0/general/decision.json
@@ -13,7 +13,8 @@
         {
           "type": "integer"
         }
-      ]
+      ],
+      "description": "The LAA Reference Number associated with the original application. For CIFC, this will refer to the original application rather than the CIFC itself."
     },
     "maat_id": {
       "anyOf": [
@@ -23,7 +24,8 @@
         {
           "type": "integer"
         }
-      ]
+      ],
+      "description": "The ID of the result in MAAT for means tested application"
     },
     "case_id": {
       "anyOf": [
@@ -87,10 +89,11 @@
             "result": {
               "type": "string",
               "enum": [
-                "passed",
-                "failed",
-                "passed_with_contribution"
-              ]
+		"passed",
+		"failed",
+		"passed_with_contribution"
+	      ],
+	      "description": "The outcome of the means test. 'passed_with_contribution' indicates that gross income is between the upper and lower thresholds, requiring a possible contribution."
             },
             "details": {
               "anyOf": [
@@ -123,7 +126,15 @@
       "enum": [
         "granted",
 	"refused"
-      ]
+      ],
+      "description": "Indicates whether legal aid funding was granted or refused."
+    },
+    "overall_result": {
+      "anyOf": [
+	{ "type": "null" },
+	{"type": "string" }
+      ],
+      "description": "The combined result of the IoJ test, Means test, and funding decision, as used in MAAT communications."
     },
     "comment": {
       "anyOf": [

--- a/schemas/1.0/general/decision.json
+++ b/schemas/1.0/general/decision.json
@@ -46,8 +46,8 @@
             "result": {
               "type": "string",
               "enum": [
-                "pass",
-                "fail"
+                "passed",
+                "failed"
               ]
             },
             "details": {
@@ -87,9 +87,9 @@
             "result": {
               "type": "string",
               "enum": [
-                "pass",
-                "fail",
-                "contribution_required"
+                "passed",
+                "failed",
+                "passed_with_contribution"
               ]
             },
             "details": {
@@ -121,8 +121,8 @@
     "funding_decision": {
       "type": "string",
       "enum": [
-        "grant",
-	"refuse"
+        "granted",
+	"refused"
       ]
     },
     "comment": {

--- a/spec/laa_crime_schemas/structs/decision_spec.rb
+++ b/spec/laa_crime_schemas/structs/decision_spec.rb
@@ -10,18 +10,18 @@ RSpec.describe LaaCrimeSchemas::Structs::Decision do
           'maat_id' => nil,
           'case_id' => "123123123",
           'interests_of_justice' => {
-            'result' => 'pass',
+            'result' => 'passed',
             'details' => 'ioj details',
             'assessed_by' => 'Grace Nolan',
             'assessed_on' => '2024-10-01 00:00:00'
           },
           'means' => {
-            'result' => 'fail',
+            'result' => 'failed',
             'details' => 'means details',
             'assessed_by' => 'Kory Liam',
             'assessed_on' => '2024-11-01 00:00:00'
           },
-          'funding_decision' => 'grant',
+          'funding_decision' => 'granted',
           'comment' => 'test comment'
         }
       end
@@ -30,15 +30,15 @@ RSpec.describe LaaCrimeSchemas::Structs::Decision do
         expect(subject.reference).to eq(1234)
         expect(subject.maat_id).to be_nil
         expect(subject.case_id).to eq("123123123")
-        expect(subject.interests_of_justice.result).to eq('pass')
+        expect(subject.interests_of_justice.result).to eq('passed')
         expect(subject.interests_of_justice.details).to eq('ioj details')
         expect(subject.interests_of_justice.assessed_by).to eq('Grace Nolan')
         expect(subject.interests_of_justice.assessed_on).to eq(Date.new(2024, 10, 1))
-        expect(subject.means.result).to eq('fail')
+        expect(subject.means.result).to eq('failed')
         expect(subject.means.details).to eq('means details')
         expect(subject.means.assessed_by).to eq('Kory Liam')
         expect(subject.means.assessed_on).to eq(Date.new(2024, 11, 1))
-        expect(subject.funding_decision).to eq('grant')
+        expect(subject.funding_decision).to eq('granted')
         expect(subject.comment).to eq('test comment')
       end
     end

--- a/spec/laa_crime_schemas/structs/test_result_spec.rb
+++ b/spec/laa_crime_schemas/structs/test_result_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe LaaCrimeSchemas::Structs::TestResult do
     context 'for a valid test_result object' do
       let(:attributes) do
         {
-          'result' => 'pass',
+          'result' => 'passed',
           'details' => 'decision details',
           'assessed_by' => 'Grace Nolan',
           'assessed_on' => '2024-10-01 00:00:00'
@@ -14,7 +14,7 @@ RSpec.describe LaaCrimeSchemas::Structs::TestResult do
       end
 
       it 'builds a test_result struct' do
-        expect(subject.result).to eq('pass')
+        expect(subject.result).to eq('passed')
         expect(subject.details).to eq('decision details')
         expect(subject.assessed_by).to eq('Grace Nolan')
         expect(subject.assessed_on).to eq(Date.new(2024, 10, 1))

--- a/spec/laa_crime_schemas/validator_spec.rb
+++ b/spec/laa_crime_schemas/validator_spec.rb
@@ -168,15 +168,15 @@ RSpec.describe LaaCrimeSchemas::Validator do
       [
         {
           'interests_of_justice' => {
-            'result' => 'pass',
+            'result' => 'passed',
             'assessed_by' => 'Kory Liam',
             'assessed_on' => '2024-10-04'
           }
         },
         {
-          'funding_decision' => 'refuse',
+          'funding_decision' => 'refused',
           'interests_of_justice' => {
-            'result' => 'pass',
+            'result' => 'failed',
             'assessed_by' => 'Kory Liam'
           }
         }


### PR DESCRIPTION
## Description of change

- Use past tense for test result and decision types.
- Store the overall decision, as shown in eForms, alongside the simplified data model for funding decisions in Crime Apply/Review. This ensures the overall result is available if needed by users.
- Add descriptions to decision attributes in the JSON schema



## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1490

## Additional notes

I have delete the v1.5.0 which this PR will replace.
