### PR TITLE
CRIMAPP-1597 restrict values for decision#overall_result

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.5.4)
+    laa-criminal-legal-aid-schemas (1.6.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/decision.rb
+++ b/lib/laa_crime_schemas/structs/decision.rb
@@ -10,7 +10,7 @@ module LaaCrimeSchemas
       attribute? :interests_of_justice, Types::Nil | TestResult
       attribute? :means, Types::Nil | TestResult
       attribute? :funding_decision, Types::FundingDecision.optional
-      attribute? :overall_result, Types::String.optional
+      attribute? :overall_result, Types::OverallResult.optional
       attribute? :comment, Types::String.optional
     end
   end

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -297,6 +297,17 @@ module LaaCrimeSchemas
     MeansResult = TestResult
     InterestsOfJusticeResult = String.enum(TestResult['passed'], TestResult['failed'])
     FundingDecision = String.enum(*%w[granted refused])
+
+    OverallResult = String.enum(*%w[
+                                  granted
+                                  granted_with_contribution
+                                  granted_failed_means
+                                  refused
+                                  refused_failed_ioj
+                                  refused_failed_ioj_and_means
+                                  refused_failed_means
+                                ])
+
     CourtType = String.enum('crown', 'magistrates')
   end
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.5.4'
+  VERSION = '1.6.0'
 end

--- a/schemas/1.0/general/decision.json
+++ b/schemas/1.0/general/decision.json
@@ -150,10 +150,19 @@
           "type": "null"
         },
         {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "granted",
+            "granted_with_contribution",
+            "granted_failed_means",
+            "refused",
+            "refused_failed_ioj",
+            "refused_failed_ioj_and_means",
+            "refused_failed_means"
+          ]
         }
       ],
-      "description": "The combined result of the IoJ test, Means test, and funding decision, as used in MAAT communications."
+      "description": "The overall result of the funding decision including relvant qualification."
     },
     "comment": {
       "anyOf": [


### PR DESCRIPTION
## Description of change

Store `overall_result` as a type

## Link to relevant ticket

[CRIMAPP-1597](https://dsdmoj.atlassian.net/browse/CRIMAPP-1597)

## Additional notes

The initial plan was to store MAAT strings directly in the datastore `overall_result`, as MAAT is the source of truth for decisions and its logic is complex. However, testing has shown that these strings do not fully meet providers' needs and may cause confusion.

Instead, we will store a constant representing the overall result, which clients can translate into text as needed. This result will combine the funding_decision with any relevant qualifications that help providers understand the next steps.

[CRIMAPP-1597]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ