### PR TITLE
CRIMAPP-1630 handle all assessment rules and introduce refused_ineligible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.6.0)
+    laa-criminal-legal-aid-schemas (1.6.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.6.1)
+    laa-criminal-legal-aid-schemas (1.7.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/structs/decision.rb
+++ b/lib/laa_crime_schemas/structs/decision.rb
@@ -6,7 +6,7 @@ module LaaCrimeSchemas
       attribute? :reference, Types::Integer.optional
       attribute? :maat_id, Types::Integer.optional
       attribute? :case_id, Types::String.optional
-      attribute? :court_type, Types::CourtType.optional
+      attribute? :assessment_rules, Types::AssessmentRules.optional
       attribute? :interests_of_justice, Types::Nil | TestResult
       attribute? :means, Types::Nil | TestResult
       attribute? :funding_decision, Types::FundingDecision.optional

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -306,6 +306,7 @@ module LaaCrimeSchemas
                                   refused_failed_ioj
                                   refused_failed_ioj_and_means
                                   refused_failed_means
+                                  refused_ineligible
                                 ])
 
     CourtType = String.enum('crown', 'magistrates')

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -298,6 +298,14 @@ module LaaCrimeSchemas
     InterestsOfJusticeResult = String.enum(TestResult['passed'], TestResult['failed'])
     FundingDecision = String.enum(*%w[granted refused])
 
+    AssessmentRules = String.enum(*%w[
+                                    appeal_to_crown_court
+                                    committal_for_sentence
+                                    crown_court
+                                    magistrates_court
+                                    non_means
+                                  ])
+
     OverallResult = String.enum(*%w[
                                   granted
                                   granted_with_contribution
@@ -308,8 +316,6 @@ module LaaCrimeSchemas
                                   refused_failed_means
                                   refused_ineligible
                                 ])
-
-    CourtType = String.enum('crown', 'magistrates')
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.6.1'
+  VERSION = '1.7.0'
 end

--- a/schemas/1.0/general/decision.json
+++ b/schemas/1.0/general/decision.json
@@ -158,7 +158,8 @@
             "refused",
             "refused_failed_ioj",
             "refused_failed_ioj_and_means",
-            "refused_failed_means"
+            "refused_failed_means",
+            "refused_ineligible"
           ]
         }
       ],

--- a/schemas/1.0/general/decision.json
+++ b/schemas/1.0/general/decision.json
@@ -121,20 +121,16 @@
         }
       ]
     },
-    "court_type": {
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string",
-          "enum": [
-            "crown",
-            "magistrates"
-          ]
-        }
+    "assessment_rules": {
+      "type": "string",
+      "enum": [
+        "appeal_to_crown_court",
+        "committal_for_sentence",
+        "crown_court",
+        "magistrates_court",
+        "non_means"
       ],
-      "description": "The court type of the MAAT means result and MAAT funding decision used in this decision"
+      "description": "The assessment rules used to determine the means test and overall result"
     },
     "funding_decision": {
       "type": "string",

--- a/spec/laa_crime_schemas/structs/decision_spec.rb
+++ b/spec/laa_crime_schemas/structs/decision_spec.rb
@@ -1,4 +1,3 @@
-
 RSpec.describe LaaCrimeSchemas::Structs::Decision do
   subject { described_class.new(attributes) }
 
@@ -8,7 +7,8 @@ RSpec.describe LaaCrimeSchemas::Structs::Decision do
         {
           'reference' => 1234,
           'maat_id' => nil,
-          'case_id' => "123123123",
+          'case_id' => '123123123',
+          'assessment_rules' => 'committal_for_sentence',
           'interests_of_justice' => {
             'result' => 'passed',
             'details' => 'ioj details',
@@ -29,7 +29,8 @@ RSpec.describe LaaCrimeSchemas::Structs::Decision do
       it 'builds a decision struct' do
         expect(subject.reference).to eq(1234)
         expect(subject.maat_id).to be_nil
-        expect(subject.case_id).to eq("123123123")
+        expect(subject.case_id).to eq('123123123')
+        expect(subject.assessment_rules).to eq('committal_for_sentence')
         expect(subject.interests_of_justice.result).to eq('passed')
         expect(subject.interests_of_justice.details).to eq('ioj details')
         expect(subject.interests_of_justice.assessed_by).to eq('Grace Nolan')


### PR DESCRIPTION
## Description of change
This PR introduces an `overall_result` type of `refused_ineligible` it also replaces `court_type` with `assessment_rules`, so that all the assessment rules used for the means test can be differentiated.

Add the following assessment types: Crown Court, Magistrates Court, Non-means, Committal for sentence , Appeal to Crown Court

## Link to relevant ticket

[CRIMAPP-1630](https://dsdmoj.atlassian.net/browse/CRIMAPP-1630)

## Additional notes


[CRIMAPP-1630]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ