### PR TITLE
Flexible API interface for removed crime applications

### DIFF
--- a/lib/laa_crime_schemas/structs/applicant.rb
+++ b/lib/laa_crime_schemas/structs/applicant.rb
@@ -3,7 +3,7 @@
 module LaaCrimeSchemas
   module Structs
     class Applicant < Person
-      attribute :date_of_birth, Types::JSON::Date
+      attribute? :date_of_birth, Types::JSON::Date.optional
       attribute? :benefit_type, Types::BenefitType.optional
       attribute? :last_jsa_appointment_date, Types::JSON::Date.optional
       attribute? :has_arc, Types::String.optional

--- a/lib/laa_crime_schemas/structs/base_application.rb
+++ b/lib/laa_crime_schemas/structs/base_application.rb
@@ -18,7 +18,7 @@ module LaaCrimeSchemas
       attribute :created_at, Types::JSON::DateTime
       attribute :submitted_at, Types::JSON::DateTime.optional
       attribute? :date_stamp, Types::JSON::DateTime.optional
-      attribute? :date_stamp_context, DateStampContext
+      attribute? :date_stamp_context, DateStampContext.optional
       attribute? :returned_at, Types::JSON::DateTime.optional
       attribute? :reviewed_at, Types::JSON::DateTime.optional
     end

--- a/lib/laa_crime_schemas/structs/crime_application.rb
+++ b/lib/laa_crime_schemas/structs/crime_application.rb
@@ -4,29 +4,29 @@ module LaaCrimeSchemas
   module Structs
     class CrimeApplication < BaseApplication
       attribute? :is_means_tested, Types::String.optional
-      attribute? :ioj_passport, Types::Array.of(Types::IojPassportType).default([].freeze)
-      attribute? :means_passport, Types::Array.of(Types::MeansPassportType).default([].freeze)
+      attribute? :ioj_passport, Types::Coercible::Array.of(Types::IojPassportType).default([].freeze)
+      attribute? :means_passport, Types::Coercible::Array.of(Types::MeansPassportType).default([].freeze)
 
-      attribute? :provider_details, ProviderDetails
+      attribute? :provider_details, ProviderDetails.optional
 
-      attribute :client_details, Base do
-        attribute :applicant, Applicant
-        attribute? :partner, Partner
+      attribute? :client_details, Base do
+        attribute? :applicant, Applicant.optional
+        attribute? :partner, Partner.optional
       end
 
-      attribute? :case_details, CaseDetails
+      attribute? :case_details, CaseDetails.optional
 
       attribute? :interests_of_justice, Types::Coercible::Array.of(Base).default([].freeze) do
-        attribute :type, Types::IojType
-        attribute :reason, Types::String
+        attribute? :type, Types::IojType.optional
+        attribute? :reason, Types::String.optional
       end
 
-      attribute? :means_details, MeansDetails
+      attribute? :means_details, MeansDetails.optional
 
-      attribute? :supporting_evidence, Types::Array.of(Document).default([].freeze)
-      attribute? :evidence_details, EvidenceDetails
+      attribute? :supporting_evidence, Types::Coercible::Array.of(Document).default([].freeze)
+      attribute? :evidence_details, EvidenceDetails.optional
 
-      attribute? :return_details, ReturnDetails
+      attribute? :return_details, ReturnDetails.optional
 
       attribute? :work_stream, Types::WorkStreamType.optional
 
@@ -37,7 +37,7 @@ module LaaCrimeSchemas
       attribute? :pre_cifc_usn, Types::String.optional
       attribute? :pre_cifc_reason, Types::String.optional
 
-      attribute? :decisions, Types::Array.of(Decision).default([].freeze)
+      attribute? :decisions, Types::Coercible::Array.of(Decision).default([].freeze)
     end
   end
 end


### PR DESCRIPTION
## Description of change
Part of Review investigation for removing crime applications. 

In order for removed Crime Applications to be built in Crime Review, the schema now needs to allow for flexible types. Otherwise, trying to build an application with nil values breaks the Dry Types Schema expectation. - https://github.com/ministryofjustice/laa-review-criminal-legal-aid/blob/3ceaa5862e1c4fe1531c0f0c79c30aa852b1b1b9/app/models/crime_application.rb#L84

Coercible Types change nil to an empty array. This hopefully prevents downstream invalid type errors to array attributes within the service. 

## Link to relevant ticket

## Additional notes
