### PR TITLE
CRIMAPP-2167: Add frozen income or assets subject to means schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.7.9)
+    laa-criminal-legal-aid-schemas (1.8.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
@@ -96,7 +96,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     unicode-display_width (3.1.2)
       unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-emoji (4.2.0)
     zeitwerk (2.6.13)
 
 PLATFORMS

--- a/lib/laa_crime_schemas/structs/capital_details.rb
+++ b/lib/laa_crime_schemas/structs/capital_details.rb
@@ -32,6 +32,7 @@ module LaaCrimeSchemas
       attribute? :national_savings_certificates, Types::Array.of(NationalSavingsCertificate).default([].freeze)
 
       attribute? :has_frozen_income_or_assets, Types::YesNoValue.optional
+      attribute? :frozen_income_or_assets_subject, Types::FrozenIncomeOrAssetsSubject.optional
       attribute? :has_no_other_assets, Types::YesNoValue.optional
     end
   end

--- a/lib/laa_crime_schemas/structs/income_details.rb
+++ b/lib/laa_crime_schemas/structs/income_details.rb
@@ -12,6 +12,7 @@ module LaaCrimeSchemas
       attribute? :lost_job_in_custody, Types::YesNoValue.optional
       attribute? :date_job_lost, Types::JSON::Date.optional
       attribute? :has_frozen_income_or_assets, Types::YesNoValue.optional
+      attribute? :frozen_income_or_assets_subject, Types::FrozenIncomeOrAssetsSubject.optional
       attribute? :has_savings, Types::YesNoValue.optional
       attribute? :manage_without_income, Types::ManageWithoutIncomeTypes.optional
       attribute? :manage_other_details, Types::String.optional

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -233,6 +233,14 @@ module LaaCrimeSchemas
     ].freeze
     WorkStreamType = Coercible::String.enum(*WORK_STREAM_TYPES)
 
+    FROZEN_INCOME_OR_ASSETS_SUBJECTS = %w[
+      client
+      partner
+      client_and_partner
+    ].freeze
+
+    FrozenIncomeOrAssetsSubject = String.enum(*FROZEN_INCOME_OR_ASSETS_SUBJECTS)
+
     SavingType = String.enum(*%w[
                                bank
                                building_society

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.7.9'
+  VERSION = '1.8.0'
 end

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -129,12 +129,13 @@
             }
           ]
         },
-        "frozen_income_or_assets_subject": { 
-          "anyOf": [
+        "frozen_income_or_assets_subject":{
+          "anyOf":[
             {
-              "type": "null"
-            }, {
-              "type": "string",
+              "type":"null"
+            },
+            {
+              "type":"string",
               "enum": ["client", "partner", "client_and_partner"]
             }
           ]

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -129,6 +129,17 @@
             }
           ]
         },
+        "frozen_income_or_assets_subject": { 
+          "anyOf": [
+            {
+              "type": "null"
+            }, {
+              "type": "string",
+              "enum": ["client", "partner", "client_and_partner"]
+            }
+          ]
+        },
+
         "has_no_income_payments":{
           "anyOf":[
             {
@@ -429,6 +440,7 @@
         "partner_trust_fund_amount_held":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "partner_trust_fund_yearly_dividend":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "has_frozen_income_or_assets": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
+        "frozen_income_or_assets_subject": { "anyOf": [{"type": "null" }, {"type": "string", "enum": ["client", "partner", "client_and_partner"]}]},
         "has_no_savings": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "has_no_properties": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "has_no_investments": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},

--- a/spec/fixtures/application/1.0/application.json
+++ b/spec/fixtures/application/1.0/application.json
@@ -179,6 +179,7 @@
       "date_job_lost": "2023-09-01",
       "income_above_threshold": "no",
       "has_frozen_income_or_assets": "no",
+      "frozen_income_or_assets_subject": null,
       "client_owns_property": "no",
       "has_savings": "yes",
       "employments": [
@@ -460,6 +461,7 @@
         }
       ],
       "has_frozen_income_or_assets": null,
+      "frozen_income_or_assets_subject": null,
       "has_no_other_assets": "yes"
     }
   },

--- a/spec/fixtures/application/1.0/change_in_financial_circumstances.json
+++ b/spec/fixtures/application/1.0/change_in_financial_circumstances.json
@@ -141,6 +141,7 @@
       "date_job_lost": "2023-09-01",
       "income_above_threshold": "no",
       "has_frozen_income_or_assets": "no",
+      "frozen_income_or_assets_subject": null,
       "client_owns_property": "no",
       "has_savings": "yes",
       "employments": [
@@ -422,6 +423,7 @@
         }
       ],
       "has_frozen_income_or_assets": null,
+      "frozen_income_or_assets_subject": null,
       "has_no_other_assets": "yes"
     }
   },

--- a/spec/fixtures/application/1.0/means.json
+++ b/spec/fixtures/application/1.0/means.json
@@ -117,6 +117,7 @@
     "date_job_lost": "2023-09-01",
     "income_above_threshold": "no",
     "has_frozen_income_or_assets": "no",
+    "frozen_income_or_assets_subject": null,
     "client_has_dependants": "yes",
     "client_owns_property": "no",
     "has_savings": "yes",
@@ -286,6 +287,7 @@
         ]
       }
     ],
-    "has_frozen_income_or_assets": null
+    "has_frozen_income_or_assets": null,
+    "frozen_income_or_assets_subject": null
   }
 }

--- a/spec/laa_crime_schemas/types/types_spec.rb
+++ b/spec/laa_crime_schemas/types/types_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe LaaCrimeSchemas::Types do
       end
     end
 
+    context 'for FrozenIncomeOrAssetsSubject' do
+      it 'returns all frozen income or assets subject values' do
+        expect(LaaCrimeSchemas::Types::FrozenIncomeOrAssetsSubject.values).to match_array(%w[
+          client
+          partner
+          client_and_partner
+        ])
+      end
+    end
+
     context "income payments" do
       context 'for OtherIncomePaymentType' do
         it 'returns other income payment types' do


### PR DESCRIPTION
## Description of change

Adds support for capturing who a restraint or freezing order relates to within the means schema.

Changes include:

* Added `FrozenIncomeOrAssetsSubject` enum type with values:

  * `client`
  * `partner`
  * `client_and_partner`
* Added `frozen_income_or_assets_subject` to:

  * `IncomeDetails`
  * `CapitalDetails`
* Updated `schemas/1.0/means.json` to include the new field for both income and capital details.
* Updated application and means fixtures to include the new attribute.
* Added test coverage for the new enum values.
* Bumped gem version to `1.8.0`.

## Link to relevant ticket

CRIMAPP-2167

## Additional notes

This change is backwards compatible. The new field is optional and supports applications where a restraint or freezing order applies to the client, their partner, or both.
