### PR TITLE
CRIMAPP-2167: Align frozen assets subject enum with existing schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    laa-criminal-legal-aid-schemas (1.8.0)
+    laa-criminal-legal-aid-schemas (1.8.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/lib/laa_crime_schemas/types/types.rb
+++ b/lib/laa_crime_schemas/types/types.rb
@@ -234,9 +234,9 @@ module LaaCrimeSchemas
     WorkStreamType = Coercible::String.enum(*WORK_STREAM_TYPES)
 
     FROZEN_INCOME_OR_ASSETS_SUBJECTS = %w[
-      client
+      applicant
       partner
-      client_and_partner
+      applicant_and_partner
     ].freeze
 
     FrozenIncomeOrAssetsSubject = String.enum(*FROZEN_INCOME_OR_ASSETS_SUBJECTS)

--- a/lib/laa_crime_schemas/version.rb
+++ b/lib/laa_crime_schemas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LaaCrimeSchemas
-  VERSION = '1.8.0'
+  VERSION = '1.8.1'
 end

--- a/schemas/1.0/means.json
+++ b/schemas/1.0/means.json
@@ -136,7 +136,7 @@
             },
             {
               "type":"string",
-              "enum": ["client", "partner", "client_and_partner"]
+              "enum": ["applicant", "partner", "applicant_and_partner"]
             }
           ]
         },
@@ -441,7 +441,7 @@
         "partner_trust_fund_amount_held":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "partner_trust_fund_yearly_dividend":{"anyOf":[{ "type":"null" }, { "type":"integer" }]},
         "has_frozen_income_or_assets": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
-        "frozen_income_or_assets_subject": { "anyOf": [{"type": "null" }, {"type": "string", "enum": ["client", "partner", "client_and_partner"]}]},
+        "frozen_income_or_assets_subject": { "anyOf": [{"type": "null" }, {"type": "string", "enum": ["applicant", "partner", "applicant_and_partner"]}]},
         "has_no_savings": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "has_no_properties": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},
         "has_no_investments": { "anyOf": [{"type": "null"}, {"type": "string", "enum": ["yes", "no"]}]},

--- a/spec/laa_crime_schemas/types/types_spec.rb
+++ b/spec/laa_crime_schemas/types/types_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe LaaCrimeSchemas::Types do
     context 'for FrozenIncomeOrAssetsSubject' do
       it 'returns all frozen income or assets subject values' do
         expect(LaaCrimeSchemas::Types::FrozenIncomeOrAssetsSubject.values).to match_array(%w[
-          client
+          applicant
           partner
-          client_and_partner
+          applicant_and_partner
         ])
       end
     end


### PR DESCRIPTION
## Description of change
Replace the new frozen income or assets subject enum values with the existing applicant-based terminology used throughout the schemas.

- Change the enum values from client/client_and_partner to applicant/applicant_and_partner
- Update the type spec to reflect the renamed values
- Bump the gem version to v1.8.1

## Link to relevant ticket
CRIMAPP-2167
## Additional notes
